### PR TITLE
[57757] Field type editable-selected after add

### DIFF
--- a/src/main/webapp/admin/v9/npm_packages/webjetdatatables/field-type-select-editable.js
+++ b/src/main/webapp/admin/v9/npm_packages/webjetdatatables/field-type-select-editable.js
@@ -26,14 +26,22 @@ export function typeSelectEditable() {
                 let iframeWindow = detail.window;
                 //console.log("iframeWindow=", iframeWindow.location.href);
                 iframeWindow.addEventListener("WJ.DTE.close", function(event) {
-                    //console.log("CLOSE EVENT RECEIVED, event=", event);
-
                     //ulozenie nested modalu nema sposobit zatvorenie okna
                     if (true===event.detail.dte.TABLE.DATA.nestedModal) return;
-
+                
+                    const $select = conf._input;
+                    const oldOptions = Array.from($select[0].options).map(opt => opt.value);
+                
                     WJ.closeIframeModal();
                     //vyvolaj nacitanie JSON optionov
-                    EDITOR.TABLE.wjUpdateOptions();
+                    EDITOR.TABLE.wjUpdateOptions(null, () => {
+                        const newOptions = Array.from($select[0].options).map(opt => opt.value);
+                        const added = newOptions.filter(val => !oldOptions.includes(val));
+                
+                        if (added.length === 1) {
+                            $select.val(added[0]).trigger("change");
+                        }
+                    });
                 });
                 iframeWindow.addEventListener("WJ.DTE.open", function(event) {
                     iframeWindow.$("#modalIframeLoader").css("display", "none");

--- a/src/main/webapp/admin/v9/npm_packages/webjetdatatables/index.js
+++ b/src/main/webapp/admin/v9/npm_packages/webjetdatatables/index.js
@@ -390,7 +390,7 @@ export const dataTableInit = options => {
             dtWJ.adjustColumns(TABLE);
         }, 100);
 
-        if (DATA.customFieldsUpdateColumns===true && json.data.length>0) {
+        if (DATA.customFieldsUpdateColumns===true && json.data !== undefined && json.data.length>0) {
             let fieldsDefinition = json.data[0]?.editorFields?.fieldsDefinition;
             if (typeof fieldsDefinition != "undefined" && fieldsDefinition != null) {
                 //je to zoznam nazvov volnych poli


### PR DESCRIPTION
JAKUB: Vo WebJETe mame typ poľa Výberové pole s možnosťou editácie:

https://docs.webjetcms.sk/latest/sk/developer/datatables-editor/field-select-editable

to umožňuje otvoriť editor inej datatabuľky a upraviť, alebo pridať záznam. Problém je, že keď sa pridá záznam, tak sa nezvolí vo výberovom poli, musíš ho manuálne vybrať, čo je používateľsky nesprávne. Tieto polia nájdeš keď v kóde vyhľadáš data-dt-edit-url, v podstate sa používa u nás hlavne v editore stránok v karte Šablóna.

Kód je implementovaný v field-type-select-editable.js, doležitý kód je okolo riadku 34:

WJ.closeIframeModal();
                    //vyvolaj nacitanie JSON optionov
                    EDITOR.TABLE.wjUpdateOptions();

kde sa vyvolá po uložení záznamu v popup okne aktualizácia select poľa.

Tu bude tricky part - keďže nevieme presne aké sa používajú label a value pre select bude potrebné pred volaním EDITOR.TABLE.wjUpdateOptions si odložiť aktuálne options (k selectu sa dostaneš ako conf._input) a po skončení wjUpdateOptions zistíš čo pribudlo a to vyberieš. Ak nepribudlo nič (nastane v prípade edit) tak samozrejme nespravíš nič. Tomu wjUpdateOptions bude potrebné parametricky pridať callback funkciu, ktorú to vyvolá po skončení aktualízácie (keďže je to celé async a čaká sa na ajax).

Samozrejme, robíš to na github verzii z main branche.