### PR TITLE
hotfix/57637-externa-linka-nezmeni-sa-v-cache

### DIFF
--- a/src/main/java/sk/iway/iwcm/doc/DocBasic.java
+++ b/src/main/java/sk/iway/iwcm/doc/DocBasic.java
@@ -1894,7 +1894,6 @@ public class DocBasic implements DocGroupInterface, Serializable
 	}
 
 	public void setExternalLink(String externalLink) {
-		if (isEmpty(externalLink)) return;
 		this.externalLink = externalLink;
 	}
 


### PR DESCRIPTION
Pri uprave stranky nastavim external link, nasledne ju zmazem. V cache pri volani DocDB.updateInternalCache sa pri zapise doc.setExternalLink prazdna hodnota nenastavi, lebo taka je podmienka v DocDetails.

Prejavuje sa to v sitemap, kde sa stranka po odmazani external link neobjavi.