### PR TITLE
Hotfix/57833-deepl-translate-http-429--too-many-requests

### DIFF
--- a/docs/sk/CHANGELOG-2025.md
+++ b/docs/sk/CHANGELOG-2025.md
@@ -22,6 +22,7 @@
 - Web stránky - schvaľovanie - opravené načítanie zoznamu v karte Neschválené pri použití databázového servera `Oracle` (#54273-62).
 - Web stránky - opravená aktualizácia nodov clustra pri zmene značiek (#57717).
 - Web stránky - opravené zobrazenie zoznamu stránok ak má používateľ právo iba na vybrané webové stránky (#57725-4).
+- Web stránky - doplnený prepínač domén aj keď nie je nastavená konfiguračná premenna `enableStaticFilesExternalDir` ale len `multiDomainEnabled` (#57833).
 - Aplikácie - opravené zobrazenie karty prekladové kľúče pri použití komponenty `editor_component_universal.jsp` (#54273-57).
 - Aplikácie - pridaná podpora vkladania nového riadku cez klávesovú skratku `SHIFT+ENTER` do jednoduchého textového editora používaného napr. v Otázky a odpovede (#57725-1).
 - Číselníky - presunutý výber číselníka priamo do nástrojovej lišty dátovej tabuľky (#49144).
@@ -42,7 +43,7 @@
 - Klonovanie štruktúry - pridaný preklad perex anotácie automatickom preklade stránok (#57833).
 - Prieskumník - opravené práva nastavenia vlastností priečinku a súboru (#57833).
 - Monitorovanie servera - opravené hlásenie o nastavení konfiguračnej premennej pre Aplikácie, WEB stránky a SQL dotazy (#57833).
-- Web stránky - doplnený prepínač domén aj keď nie je nastavená konfiguračná premenna `enableStaticFilesExternalDir` ale len `multiDomainEnabled` (#57833).
+- Úvod - opravené zobrazenie požiadavky na dvojstupňové overovanie pri integrácii cez `IIS` (#57833).
 
 ### Bezpečnosť
 

--- a/docs/sk/CHANGELOG-2025.md
+++ b/docs/sk/CHANGELOG-2025.md
@@ -37,6 +37,9 @@
 - Používatelia - upravené nastavenie práv - zjednodušené nastavenie práv administrátorov a registrovaných používateľov (už nie je potrebné zvoliť aj právo Používatelia), opravené duplicitné položky, upravené zoskupenie v sekcii Šablóny (#57725-4).
 - Prieskumník - doplnené lepšie hlásenia pri chybe vytvorenia ZIP archívu (#56058).
 - Štatistika - opravené vytvorenie tabuľky pre štatistiku kliknutí v teplotnej mape.
+- Prekladač - implementácia inteligentného oneskorenia pre prekladač `DeepL` ako ochrana proti chybe `HTTP 429: too many requests`, ktorá spôsobovala výpadok prekladov (#57833).
+- Klonovanie štruktúry - opravené nechcené prekladanie implementácie aplikácií `!INCLUDE(...)!`, pri automatickom preklade tela stránky (#57833).
+- Klonovanie štruktúry - pridaný preklad perex anotácie automatickom preklade stránok (#57833).
 
 ### Bezpečnosť
 

--- a/docs/sk/CHANGELOG-2025.md
+++ b/docs/sk/CHANGELOG-2025.md
@@ -40,6 +40,9 @@
 - Prekladač - implementácia inteligentného oneskorenia pre prekladač `DeepL` ako ochrana proti chybe `HTTP 429: too many requests`, ktorá spôsobovala výpadok prekladov (#57833).
 - Klonovanie štruktúry - opravené nechcené prekladanie implementácie aplikácií `!INCLUDE(...)!`, pri automatickom preklade tela stránky (#57833).
 - Klonovanie štruktúry - pridaný preklad perex anotácie automatickom preklade stránok (#57833).
+- Prieskumník - opravené práva nastavenia vlastností priečinku a súboru (#57833).
+- Monitorovanie servera - opravené hlásenie o nastavení konfiguračnej premennej pre Aplikácie, WEB stránky a SQL dotazy (#57833).
+- Web stránky - doplnený prepínač domén aj keď nie je nastavená konfiguračná premenna `enableStaticFilesExternalDir` ale len `multiDomainEnabled` (#57833).
 
 ### Bezpečnosť
 

--- a/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
+++ b/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
@@ -266,6 +266,9 @@ public class DocMirroringServiceV9 {
 
       doc.setNavbar(translator.translate(source.getNavbar()));
 
+      // translate perex
+      doc.setHtmlData(translator.translate(source.getHtmlData()));
+
       //regenerate URL based on title
       doc.setVirtualPath("");
 

--- a/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
+++ b/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
@@ -272,6 +272,17 @@ public class DocMirroringServiceV9 {
       //regenerate URL based on title
       doc.setVirtualPath("");
 
+      //translate doc body
+      translateDocBody(source, doc, translator);
+   }
+
+   /**
+    * Translate doc body using translator. Before translation, parse out all !INCLUDE()! and replace them with placeholders.
+    * After translation, replace placeholders with original !INCLUDE()! text.
+    * 
+    * IF during replacing something goes wrong, we wil translate original doc data without replacing.
+    */
+   private static void translateDocBody(DocDetails source, DocDetails doc, TranslationService translator) {
       Map<Integer, String> replacedIncludes = new HashMap<>();
       String docData = source.getData();
       try {

--- a/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
+++ b/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
@@ -3,11 +3,7 @@ package sk.iway.iwcm.components.structuremirroring;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import sk.iway.iwcm.Constants;
 import sk.iway.iwcm.LabelValueDetails;
@@ -273,55 +269,7 @@ public class DocMirroringServiceV9 {
       doc.setVirtualPath("");
 
       //translate doc body
-      translateDocBody(source, doc, translator);
-   }
-
-   /**
-    * Translate doc body using translator. Before translation, parse out all !INCLUDE()! and replace them with placeholders.
-    * After translation, replace placeholders with original !INCLUDE()! text.
-    * 
-    * IF during replacing something goes wrong, we wil translate original doc data without replacing.
-    */
-   private static void translateDocBody(DocDetails source, DocDetails doc, TranslationService translator) {
-      Map<Integer, String> replacedIncludes = new HashMap<>();
-      String docData = source.getData();
-      try {
-         String regex = "(!INCLUDE\\([^)]+\\)!)";
-         Pattern pattern = Pattern.compile(regex);
-         Matcher matcher = pattern.matcher(docData);
-
-         int findIncludes = 1;
-         while (matcher.find()) {
-            String replaceText = "__INCLUDE_PLACEHOLDER_" + findIncludes + "__";
-            replacedIncludes.put(findIncludes, matcher.group());
-            docData = docData.replaceFirst(Pattern.quote(matcher.group()), Matcher.quoteReplacement(replaceText));
-            findIncludes++;
-         }
-         doc.setData( docData );
-      } catch (Exception ex) {
-         //Something went wrong, we will not doc data
-         Logger.debug(DocMirroringServiceV9.class, "Error while extracting !INLCUDE()! from doc data.", ex);
-         replacedIncludes.clear();
-      }
-
-      if(replacedIncludes.isEmpty() == true) {
-        //Translate without include replenish
-        doc.setData(translator.translate(source.getData()));
-      } else {
-         try {
-            String translatedDocData = translator.translate(docData);
-            for(Map.Entry<Integer, String> entry : replacedIncludes.entrySet()) {
-               String replaceText = "__INCLUDE_PLACEHOLDER_" + entry.getKey() + "__";
-               translatedDocData = translatedDocData.replace(replaceText, Matcher.quoteReplacement(entry.getValue()));
-            }
-            doc.setData(translatedDocData);
-         } catch (Exception ex) {
-            //Something went wrong, we will not doc data
-            Logger.debug(DocMirroringServiceV9.class, "Error while returning !INLCUDE()! in doc data after translate. Use doc data translation without replacing.", ex);
-            // Translate default doc data
-            doc.setData(translator.translate(source.getData()));
-         }
-      }
+      doc.setData(translator.translate(source.getData()));
    }
 
    /**

--- a/src/main/java/sk/iway/iwcm/components/welcome/DashboardListener.java
+++ b/src/main/java/sk/iway/iwcm/components/welcome/DashboardListener.java
@@ -31,6 +31,7 @@ import sk.iway.iwcm.i18n.Prop;
 import sk.iway.iwcm.io.IwcmFile;
 import sk.iway.iwcm.stat.SessionDetails;
 import sk.iway.iwcm.stat.SessionHolder;
+import sk.iway.iwcm.system.ntlm.AuthenticationFilter;
 import sk.iway.iwcm.system.spring.events.WebjetEvent;
 import sk.iway.iwcm.users.UserDetails;
 import sk.iway.iwcm.users.UsersDB;
@@ -166,7 +167,7 @@ public class DashboardListener {
 
             boolean show2FARecommendation = false;
             String overview2fawarning = prop.getText("overview.2fa.warning");
-            if (Tools.isEmpty(Constants.getString("ldapProviderUrl")) && Tools.isEmpty(Constants.getString("adminLogonMethod")) && Tools.isNotEmpty(overview2fawarning) && overview2fawarning.length() > 2) {
+            if (Tools.isEmpty(Constants.getString("ldapProviderUrl")) && Tools.isEmpty(Constants.getString("adminLogonMethod")) && AuthenticationFilter.weTrustIIS()==false && Tools.isNotEmpty(overview2fawarning) && overview2fawarning.length() > 2) {
                 String mobileDevice = userDetailsRepository.getMobileDeviceByUserId((long)user.getUserId());
                 if (Tools.isEmpty(mobileDevice)) {
                     show2FARecommendation = true;

--- a/src/main/java/sk/iway/iwcm/system/elfinder/FileHistoryRestController.java
+++ b/src/main/java/sk/iway/iwcm/system/elfinder/FileHistoryRestController.java
@@ -25,10 +25,10 @@ import sk.iway.iwcm.users.UsersDB;
 
 @RestController
 @RequestMapping("/admin/rest/elfinder/file-history/")
-@PreAuthorize("@WebjetSecurityService.hasPermission('cmp_elfinder')")
+@PreAuthorize("@WebjetSecurityService.hasPermission('menuFbrowser')")
 @Datatable
 public class FileHistoryRestController extends DatatableRestControllerV2<FileHistoryEntity, Long> {
-    
+
     private final FileHistoryRepository fileHistoryRepository;
 
     @Autowired
@@ -64,7 +64,7 @@ public class FileHistoryRestController extends DatatableRestControllerV2<FileHis
     public boolean processAction(FileHistoryEntity entity, String action) {
         if ("rollBack".equals(action)) {
             IwcmFile historyFile = new IwcmFile( Tools.getRealPath( entity.getHistoryPath() + entity.getId() ) );
-            
+
             if(historyFile.exists() == false){
                 addNotify(new NotifyBean(getProp().getText("elfinder.file_prop.rollback.title"), getProp().getText("elfinder.file_prop.rollback.src_file_not_found.err"), NotifyType.ERROR, 15000));
                 return true;
@@ -75,10 +75,10 @@ public class FileHistoryRestController extends DatatableRestControllerV2<FileHis
                 addNotify(new NotifyBean(getProp().getText("elfinder.file_prop.rollback.title"), getProp().getText("elfinder.file_prop.rollback.src_file_not_found.err"), NotifyType.ERROR, 15000));
                 return true;
             }
-            
+
             if(FileTools.copyFile(historyFile, currentFile) == true) addNotify(new NotifyBean(getProp().getText("elfinder.file_prop.rollback.title"), getProp().getText("elfinder.file_prop.rollback.success"), NotifyType.SUCCESS, 15000));
             else addNotify(new NotifyBean(getProp().getText("elfinder.file_prop.rollback.title"), getProp().getText("elfinder.file_prop.rollback.error"), NotifyType.ERROR, 15000));
-            
+
             return true;
         }
 

--- a/src/main/java/sk/iway/iwcm/system/elfinder/FilePropertiesRestController.java
+++ b/src/main/java/sk/iway/iwcm/system/elfinder/FilePropertiesRestController.java
@@ -24,12 +24,12 @@ import sk.iway.iwcm.system.datatable.DatatableRestControllerV2;
 
 @RestController
 @RequestMapping("/admin/rest/elfinder/file-properties/")
-@PreAuthorize("@WebjetSecurityService.hasPermission('cmp_elfinder')")
+@PreAuthorize("@WebjetSecurityService.hasPermission('menuFbrowser')")
 @Datatable
 public class FilePropertiesRestController extends DatatableRestControllerV2<FilePropertiesDTO, Long> {
 
     private HttpServletResponse response;
-    
+
     @Autowired
     public FilePropertiesRestController(HttpServletResponse response) {
         super(null);
@@ -48,7 +48,7 @@ public class FilePropertiesRestController extends DatatableRestControllerV2<File
 
     @Override
     public void beforeSave(FilePropertiesDTO entity) {
-        if(getUser().isFolderWritable(entity.getDirPath() + "/") == false)   
+        if(getUser().isFolderWritable(entity.getDirPath() + "/") == false)
             throw new ResponseStatusException(HttpStatus.FORBIDDEN);
     }
 

--- a/src/main/java/sk/iway/iwcm/system/elfinder/FileUsageRestController.java
+++ b/src/main/java/sk/iway/iwcm/system/elfinder/FileUsageRestController.java
@@ -20,7 +20,7 @@ import sk.iway.iwcm.system.datatable.DatatableRestControllerV2;
 @RestController
 @Datatable
 @RequestMapping("/admin/rest/elfinder/file-usage")
-@PreAuthorize("@WebjetSecurityService.hasPermission('cmp_elfinder')")
+@PreAuthorize("@WebjetSecurityService.hasPermission('menuFbrowser')")
 public class FileUsageRestController extends DatatableRestControllerV2<FileUsageDTO, Long> {
 
     @Autowired

--- a/src/main/java/sk/iway/iwcm/system/elfinder/FolderPropertiesRestController.java
+++ b/src/main/java/sk/iway/iwcm/system/elfinder/FolderPropertiesRestController.java
@@ -26,10 +26,10 @@ import sk.iway.iwcm.users.UserGroupsDB;
 
 @RestController
 @RequestMapping("/admin/rest/elfinder/folder-properties/")
-@PreAuthorize("@WebjetSecurityService.hasPermission('cmp_elfinder')")
+@PreAuthorize("@WebjetSecurityService.hasPermission('menuFbrowser')")
 @Datatable
 public class FolderPropertiesRestController extends DatatableRestControllerV2<FolderPropertiesEntity, Long> {
-    
+
     private final FolderPropertiesRepository folderPropertiesRepository;
     private HttpServletResponse response;
 
@@ -54,7 +54,7 @@ public class FolderPropertiesRestController extends DatatableRestControllerV2<Fo
 
     @Override
     public void beforeSave(FolderPropertiesEntity entity) {
-        if(getUser().isFolderWritable(entity.getDirUrl() + "/") == false)   
+        if(getUser().isFolderWritable(entity.getDirUrl() + "/") == false)
             throw new ResponseStatusException(HttpStatus.FORBIDDEN);
 
         if(entity.getLogonDocId() == null) entity.setLogonDocId( -1 );

--- a/src/main/java/sk/iway/iwcm/system/translation/DeepL.java
+++ b/src/main/java/sk/iway/iwcm/system/translation/DeepL.java
@@ -3,8 +3,10 @@ package sk.iway.iwcm.system.translation;
 import java.nio.charset.StandardCharsets;
 import java.util.Hashtable;
 import java.util.Map;
+import java.util.Random;
 
 import org.apache.http.Consts;
+import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.fluent.Form;
 import org.apache.http.client.fluent.Request;
 import org.json.JSONArray;
@@ -24,6 +26,10 @@ import sk.iway.iwcm.Tools;
 public class DeepL {
 
     private static final String CACHE_KEY = "DeepL.translations";
+
+    private static final int MAX_RETRIES = 5;
+    private static final int BASE_DELAY_MS = 1000;
+    private static final Random random = new Random();
 
     private DeepL() {
         //utility class
@@ -62,36 +68,77 @@ public class DeepL {
 
         String apiUrl = Constants.getString("deepl_api_url");
 
-        try{
-            //DeepL has a problem with nbsp entity
-            text = Tools.replace(text, "&nbsp;", " ");
+        //DeepL has a problem with nbsp entity
+        text = Tools.replace(text, "&nbsp;", " ");
 
-            String response = Request.Post(apiUrl)
-                .bodyForm(Form.form()
-                    .add("text", text)
-                    .add("source_lang", fromLanguage.toUpperCase())
-                    .add("target_lang", toLanguage.toUpperCase())
-                    .add("tag_handling", "html")
-                    .build(), Consts.UTF_8)
-                .setHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
-                .setHeader("Authorization", "DeepL-Auth-Key "+getAuthKey())
-                .execute().returnContent().asString(StandardCharsets.UTF_8);
+        int attempt = 0;
+        while (attempt < MAX_RETRIES) {
+            try {
+                String response = Request.Post(apiUrl)
+                    .bodyForm(Form.form()
+                        .add("text", text)
+                        .add("source_lang", fromLanguage.toUpperCase())
+                        .add("target_lang", toLanguage.toUpperCase())
+                        .add("tag_handling", "html")
+                        .build(), Consts.UTF_8)
+                    .setHeader("Content-Type", "application/x-www-form-urlencoded; charset=utf-8")
+                    .setHeader("Authorization", "DeepL-Auth-Key "+getAuthKey())
+                    .execute().returnContent().asString(StandardCharsets.UTF_8);
 
-            JSONObject json = new JSONObject(response);
-            JSONArray translations = json.getJSONArray("translations");
-            if (translations.length()>0) {
-                translatedText = translations.getJSONObject(0).getString("text");
 
-                if (translationKey != null) translationsCache.put(translationKey, translatedText);
+                JSONObject json = new JSONObject(response);
+                JSONArray translations = json.getJSONArray("translations");
+                if (translations.length()>0) {
+                    translatedText = translations.getJSONObject(0).getString("text");
 
-                if (Tools.isNotEmpty(translatedText)) return translatedText;
+                    if (translationKey != null) translationsCache.put(translationKey, translatedText);
+
+                    if (Tools.isNotEmpty(translatedText)) return translatedText;
+                }
+
+                //Succes, break the while
+                break;
+            } catch (Exception ex1) {
+
+                if(ex1 instanceof HttpResponseException responseException) {
+                    if(responseException.getStatusCode() == 429) {
+                        try {
+                            //Too many requests, slow down
+                            int delay = getExponentialBackoffDelay(attempt);
+                            Logger.debug(DeepL.class, "To many requests error. Attempt number : " + (attempt + 1) + ", waiting for for : " + delay + " ms");
+                            Thread.sleep(delay);
+                        } catch (Exception ex2) {
+                            sk.iway.iwcm.Logger.error(ex2);
+                            break;
+                        }
+                        // Waiting done
+                        Logger.debug(DeepL.class, "Waiting done");
+                        // Increment attempt count
+                        attempt++;
+
+                        if(attempt >= MAX_RETRIES) {
+                            Logger.error(DeepL.class,"Unable to translete '" + apiUrl + "', reached maximum number of attempts");
+                            break;
+                        } else {
+                            // Try again
+                            continue;
+                        }
+                    }
+                }
+
+                Logger.error(DeepL.class,"Unable to connect to '" + apiUrl + "'");
+                Logger.error(DeepL.class, ex1);
+                break;
             }
-		} catch (Exception e){
-            Logger.error(DeepL.class,"Unable to connect to '" + apiUrl + "'");
-            Logger.error(DeepL.class, e);
         }
 
         return text;
+    }
+
+    private static int getExponentialBackoffDelay(int attempt) {
+        int exponentialDelay = BASE_DELAY_MS * (1 << attempt); // 2^attempt * base
+        // Add jitter: +/- 0-1000 ms
+        return exponentialDelay + random.nextInt(1000);
     }
 
 }

--- a/src/main/java/sk/iway/iwcm/system/translation/TranslationService.java
+++ b/src/main/java/sk/iway/iwcm/system/translation/TranslationService.java
@@ -1,10 +1,16 @@
 package sk.iway.iwcm.system.translation;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import sk.iway.iwcm.Logger;
 import sk.iway.iwcm.Tools;
+import sk.iway.iwcm.components.structuremirroring.DocMirroringServiceV9;
 
 /**
  * Vseobecna trieda pre preklad textov, vyzaduje konfiguraciu prekladaca, aktualne je podporovany DeepL
@@ -35,7 +41,49 @@ public class TranslationService {
             if (Tools.isEmpty(text) || text.contains("autotest")) return text;
             if (Tools.isEmpty(fromLanguage) || Tools.isEmpty(toLanguage) || fromLanguage.equalsIgnoreCase(toLanguage)) return text;
 
-            if (DeepL.isConfigured()) return DeepL.translate(text, fromLanguage, toLanguage);
+            if (DeepL.isConfigured()) {
+
+                // FInd and replace all !INCLUDE()! with __INCLUDE_PLACEHOLDER_x value (x is number)
+                String textToTranslate = text;
+                Map<Integer, String> replacedIncludes = new HashMap<>();
+                try {
+                    String regex = "(!INCLUDE\\([^)]+\\)!)";
+                    Pattern pattern = Pattern.compile(regex);
+                    Matcher matcher = pattern.matcher(textToTranslate);
+
+                    int findIncludes = 1;
+                    while (matcher.find()) {
+                        String replaceText = "__INCLUDE_PLACEHOLDER_" + findIncludes + "__";
+                        replacedIncludes.put(findIncludes, matcher.group());
+                        textToTranslate = textToTranslate.replaceFirst(Pattern.quote(matcher.group()), Matcher.quoteReplacement(replaceText));
+                        findIncludes++;
+                    }
+                } catch (Exception ex) {
+                    //Something went wrong, we will not doc data
+                    Logger.debug(DocMirroringServiceV9.class, "Error while extracting !INLCUDE()! from doc data.", ex);
+                    replacedIncludes.clear();
+                }
+
+                if(replacedIncludes.isEmpty() == true) {
+                    //Translate without include replenish, because there is nothing to replace
+                    return DeepL.translate(text, fromLanguage, toLanguage);
+                } else {
+                    try {
+                        String translatedText = DeepL.translate(textToTranslate, fromLanguage, toLanguage);
+                        for(Map.Entry<Integer, String> entry : replacedIncludes.entrySet()) {
+                            String replaceText = "__INCLUDE_PLACEHOLDER_" + entry.getKey() + "__";
+                            translatedText = translatedText.replace(replaceText, Matcher.quoteReplacement(entry.getValue()));
+                        }
+                        return translatedText;
+
+                    } catch (Exception ex) {
+                        //Something went wrong, we will not doc data
+                        Logger.debug(DocMirroringServiceV9.class, "Error while returning !INLCUDE()! in doc data after translate. Use doc data translation without replacing.", ex);
+                        // Translate default text
+                        return DeepL.translate(text, fromLanguage, toLanguage);
+                    }
+                }
+            }
 
         } catch (Exception ex) {
             Logger.error(TranslationService.class, ex);
@@ -43,5 +91,4 @@ public class TranslationService {
 
         return text;
     }
-
 }

--- a/src/main/webapp/WEB-INF/classes/text.properties
+++ b/src/main/webapp/WEB-INF/classes/text.properties
@@ -2356,7 +2356,7 @@ admin.clone.source_lang_name=Názov zdrojového jazyka
 admin.clone.destination_dir_id=ID cieľového adresára
 admin.clone.destination_lang_name=Názov cieľového jazyka
 admin.clone.clone=Klonovať
-admin.clone.dialogTitle=Klonovanie štrukúry
+admin.clone.dialogTitle=Klonovanie štruktúry
 admin.clone.dialogDesc=Zadajte parametre pre klonovanie adresárovej štruktúry
 
 admin.archive.dialogTitle=Vytvoriť ZIP archív

--- a/src/main/webapp/admin/v9/views/partials/sidebar.pug
+++ b/src/main/webapp/admin/v9/views/partials/sidebar.pug
@@ -22,6 +22,6 @@ div.menu-wrapper(data-scrollbar)
                 div.md-main-menu__item__sub-menu__item(data-th-each="thirdMenuItem : ${subMenuItem.childrens}" data-th-classappend="${thirdMenuItem.active} ? 'md-main-menu\\_\\_item\\_\\_sub-menu\\_\\_item--active'")
                     a.md-main-menu__item__sub-menu__item__link(data-th-href="${thirdMenuItem.href}" data-th-text="${thirdMenuItem.text}")
 
-.js-domain-toggler(data-th-if="${layout.isTypeCloud()==false && layout.getConstantBoolean('enableStaticFilesExternalDir')}")
+.js-domain-toggler(data-th-if="${layout.isTypeCloud()==false && (layout.getConstantBoolean('enableStaticFilesExternalDir') || layout.getConstantBoolean('multiDomainEnabled'))}")
     select(data-th-field="${layout.header.currentDomain}" onchange="WJ.changeDomain(this);" data-th-data-previous="${layout.header.currentDomain}" data-live-search="false" class="domain-toggler-select")
         option(data-th-each="domain : ${layout.header.domains}" data-th-text="${domain}" data-th-value="${domain}" data-icon="ti-device-desktop")

--- a/src/test/java/sk/iway/iwcm/SendMailTest.java
+++ b/src/test/java/sk/iway/iwcm/SendMailTest.java
@@ -1,0 +1,68 @@
+package sk.iway.iwcm;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class SendMailTest {
+
+    @org.junit.jupiter.params.ParameterizedTest
+    @org.junit.jupiter.params.provider.ValueSource(strings = {
+        "",
+        "<html><body><p>No images here!</p></body></html>",
+        "<img src=\"\"><img>"
+    })
+    void testGetInlineAttachments_emptyResults(String html) {
+        List<String> result = SendMail.getInlineAttachments(html);
+        assertThat(result, is(empty()));
+    }
+
+    @org.junit.jupiter.params.ParameterizedTest
+    @org.junit.jupiter.params.provider.MethodSource("provideHtmlAndExpectedResults")
+    void testGetInlineAttachments_parametrized(String html, List<String> expected) {
+        List<String> result = SendMail.getInlineAttachments(html);
+        assertThat(result, contains(expected.toArray()));
+    }
+
+    private static java.util.stream.Stream<org.junit.jupiter.params.provider.Arguments> provideHtmlAndExpectedResults() {
+        return java.util.stream.Stream.of(
+            org.junit.jupiter.params.provider.Arguments.of(
+                "<html><body><table background=\"bg1.png\"></table></body></html>",
+                java.util.List.of("bg1.png")
+            ),
+            org.junit.jupiter.params.provider.Arguments.of(
+                "<div><img src=\"img1.png\"></div>",
+                java.util.List.of("img1.png")
+            )
+        );
+    }
+
+    @org.junit.jupiter.params.ParameterizedTest
+    @org.junit.jupiter.params.provider.MethodSource("provideHtmlAndExpectedResultsExtended")
+    void testGetInlineAttachments_variousCases(String html, List<String> expected) {
+        List<String> result = SendMail.getInlineAttachments(html);
+        assertThat(result, containsInAnyOrder(expected.toArray()));
+    }
+
+    private static java.util.stream.Stream<org.junit.jupiter.params.provider.Arguments> provideHtmlAndExpectedResultsExtended() {
+        return java.util.stream.Stream.of(
+            org.junit.jupiter.params.provider.Arguments.of(
+                "<html><body><img src=\"image1.png\"><img src='image2.jpg'></body></html>",
+                java.util.List.of("image1.png", "image2.jpg")
+            ),
+            org.junit.jupiter.params.provider.Arguments.of(
+                "<img src=\"img.png\"><table background=\"bg.png\"></table>",
+                java.util.List.of("img.png", "bg.png")
+            ),
+            org.junit.jupiter.params.provider.Arguments.of(
+                "<img src=\"img1.png\"><img src=\"\"><table background=\"bg1.jpg\"></table><table background=\"\"></table>",
+                java.util.List.of("img1.png", "bg1.jpg")
+            ),
+            org.junit.jupiter.params.provider.Arguments.of(
+                "<div><img src=\"img1.png\"><table><tr><td><img src=\"img2.jpg\"></td></tr></table></div>",
+                java.util.List.of("img1.png", "img2.jpg")
+            )
+        );
+    }
+}

--- a/src/test/java/sk/iway/iwcm/system/translation/TestTranslationService.java
+++ b/src/test/java/sk/iway/iwcm/system/translation/TestTranslationService.java
@@ -1,0 +1,32 @@
+package sk.iway.iwcm.system.translation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import sk.iway.iwcm.Constants;
+import sk.iway.iwcm.DBPool;
+import sk.iway.iwcm.test.BaseWebjetTest;
+
+public class TestTranslationService extends BaseWebjetTest {
+
+    @BeforeAll
+    public static void initJpa()
+    {
+        Constants.setString("deepl_auth_key", System.getenv("DEEPL_AUTH_KEY"));
+        DBPool.getInstance();
+        DBPool.jpaInitialize();
+    }
+    
+    @Test
+    public void checkDeeplTranslation() {
+        String inputTextSk = "Toto je test : !INCLUDE(pes.jsp, ja, som, najlepší)! , tento test je povinný. Aj tento by mal fungovať : !INCLUDE(neviem.jsp, skúsim, to, znovu)! ale neviem to zaručiť.";
+        String requiredOutputEn = "This is a test : !INCLUDE(pes.jsp, ja, som, najlepší)! , this test is mandatory. Also this one should work : !INCLUDE(neviem.jsp, skúsim, to, znovu)! but I can't guarantee it.";
+
+        // Init Translate from SK to EN
+        TranslationService translator = new TranslationService("SK", "EN");
+        String realOutputEn = translator.translate(inputTextSk);
+        assertEquals(requiredOutputEn, realOutputEn);
+    }
+}

--- a/src/test/webapp/tests/webpages/clone-structure.js
+++ b/src/test/webapp/tests/webpages/clone-structure.js
@@ -8,7 +8,12 @@ var srcGroupChildName = "Subfolder-autotest";
 var destGroupName = "clone-dest-autotest-";
 var newDocName = "New page-autotest-";
 var doc_a_child_sk = '<p> auto strom </p>';
+var doc_a_child_sk_perex = 'Toto je perex.';
 var doc_b_sk = '<p> nový starý najstarší </p>';
+var doc_b_sk_perex = 'Aj toto je perex.';
+
+var fake_include = "!INCLUDE(Falošná aplikácia, vložená aplikácia sa nemôže prekladať)!";
+var fake_include_html = "<p> Text pred " + fake_include + " text po</p>";
 
 //NO TRANSLATE URL cloning test variables
 var srcGroupName_noUrlTranslate = "clone-src-noUrlTranslate-autotest-";
@@ -54,10 +59,16 @@ function createGroup(I, DTE, DT, groupName, language, isRootGroup) {
     DTE.save();
 }
 
-async function fillDocBody(I, DTE, DT, body) {
+async function fillDocBody(I, DTE, DT, body, perex) {
     I.clickCss("#datatableInit_wrapper > div:nth-child(2) > div > div > div.dt-scroll > div.dt-scroll-head > div > table > thead > tr:nth-child(2) > th.dt-format-selector.dt-th-id > form > div > button.buttons-select-all.btn.btn-sm.btn-outline-secondary.dt-filter-id");
     I.click(DT.btn.edit_button);
 
+    I.say("Filling perex");
+    I.clickCss("#pills-dt-datatableInit-perex-tab");
+    I.fillField("#DTE_Field_htmlData", perex);
+
+    I.say("Filling body");
+    I.clickCss("#pills-dt-datatableInit-content-tab");
     I.waitForElement("iframe.cke_wysiwyg_frame");
     await DTE.fillCkeditor(body);
     DTE.save();
@@ -71,14 +82,24 @@ async function editDoc(I, DT, DTE, title) {
     DTE.waitForEditor();
 }
 
-async function checkBodyEN(I, DT, DTE, title, values) {
+async function checkBodyEN(I, DT, DTE, Apps, title, values, perex) {
     await editDoc(I, DT, DTE, title);
 
+    I.say("Switch editor type to HTML");
+    Apps.switchEditor('html');
+
     I.say("Check EN translated body");
-    I.switchTo("iframe.cke_wysiwyg_frame");
-    for(var i = 0; i < values.length; i++)
-        I.see( values[i] );
-    I.switchTo();
+    within('.CodeMirror-code', () => {
+        for(var i = 0; i < values.length; i++)
+            I.see( values[i] );
+        
+        //This include must be unchanged !!!
+        I.see( fake_include );
+    });
+
+    I.say("Check EN translated perex");
+    I.clickCss("#pills-dt-datatableInit-perex-tab");
+    I.seeInField("#DTE_Field_htmlData", perex);
 
     DTE.cancel();
 }
@@ -147,7 +168,7 @@ async function hardDeleteFolder(I, DT, DTE, groupName) {
     DT.waitForLoader();
 }
 
-Scenario("Structure clonning with translate - classic", async ({ I, DTE, DT })  => {
+Scenario("Structure clonning with translate - classic", async ({ I, DTE, DT, Apps })  => {
     I.say("Preparing source folder");
         I.amOnPage('/admin/v9/webpages/web-pages-list/?groupid=9811');
         DT.waitForLoader();
@@ -160,11 +181,16 @@ Scenario("Structure clonning with translate - classic", async ({ I, DTE, DT })  
         I.say("Create new doc in root group");
             I.click(DT.btn.add_button);
             DTE.waitForEditor();
+            //Add name
             I.waitForVisible("#DTE_Field_title");
             I.fillField("#DTE_Field_title", newDocName);
+            //Add perex
+            I.clickCss("#pills-dt-datatableInit-perex-tab");
+            I.fillField("#DTE_Field_htmlData", doc_a_child_sk_perex);
+            //Fill body
             I.clickCss("#pills-dt-datatableInit-content-tab");
             I.waitForElement("iframe.cke_wysiwyg_frame");
-            await DTE.fillCkeditor(doc_a_child_sk);
+            await DTE.fillCkeditor(doc_a_child_sk + fake_include_html);
             DTE.save();
 
         //
@@ -172,7 +198,7 @@ Scenario("Structure clonning with translate - classic", async ({ I, DTE, DT })  
         createGroup(I, DTE, DT, srcGroupChildName, "Slovenský", false);
 
         I.jstreeClick(srcGroupChildName);
-        await fillDocBody(I, DTE, DT, doc_b_sk);
+        await fillDocBody(I, DTE, DT, doc_b_sk + fake_include_html, doc_b_sk_perex);
 
     I.say("Preparing dest folder");
         createGroup(I, DTE, DT, destGroupName, "Anglický", true);
@@ -186,11 +212,12 @@ Scenario("Structure clonning with translate - classic", async ({ I, DTE, DT })  
         I.amOnPage("/admin/v9/webpages/web-pages-list/");
         I.click( locate("a.jstree-anchor").withText(destGroupName) );
 
-        await checkBodyEN(I, DT, DTE, "New", ["car", "tree"]);
+
+        await checkBodyEN(I, DT, DTE, Apps, "New", ["car", "tree"], "This is a perex.");
 
         I.click( locate("a.jstree-anchor").withText("Subfolder") );
 
-        await checkBodyEN(I, DT, DTE, "Subfolder", ["new", "old", "oldest"]);
+        await checkBodyEN(I, DT, DTE, Apps, "Subfolder", ["new", "old", "oldest"], "This is also a perex.");
 
         I.say("Check folder optional fields");
         I.jstreeNavigate([destGroupName, srcGroupChildName]);

--- a/src/webjet8/java/sk/iway/iwcm/SendMail.java
+++ b/src/webjet8/java/sk/iway/iwcm/SendMail.java
@@ -618,7 +618,7 @@ public class SendMail
 						continue;
 					}
 					//Logger.println(this,src);
-					att.add(src);
+					if (att.contains(src)==false) att.add(src);
 				}
 				//jeeff: test na atribut background
 				if (elem.getAttributes().getAttribute(HTML.Attribute.BACKGROUND) != null)
@@ -629,7 +629,7 @@ public class SendMail
 						continue;
 					}
 					//Logger.println(this,src);
-					att.add(src);
+					if (att.contains(src)==false) att.add(src);
 				}
 			}
 		}

--- a/src/webjet8/java/sk/iway/iwcm/common/DocTools.java
+++ b/src/webjet8/java/sk/iway/iwcm/common/DocTools.java
@@ -698,6 +698,8 @@ public class DocTools {
             }
 
             text = updateUserCodes(user, text);
+
+
         }
         catch (Exception ex)
         {

--- a/src/webjet8/java/sk/iway/iwcm/common/DocTools.java
+++ b/src/webjet8/java/sk/iway/iwcm/common/DocTools.java
@@ -698,8 +698,6 @@ public class DocTools {
             }
 
             text = updateUserCodes(user, text);
-
-
         }
         catch (Exception ex)
         {

--- a/src/webjet8/java/sk/iway/iwcm/system/monitoring/ExecutionTimeMonitor.java
+++ b/src/webjet8/java/sk/iway/iwcm/system/monitoring/ExecutionTimeMonitor.java
@@ -142,7 +142,7 @@ public abstract class ExecutionTimeMonitor
 	public List<ExecutionEntry> generateStats()
 	{
 		if (!Constants.getBoolean("serverMonitoringEnablePerformance"))
-			throw new IllegalStateException(Prop.getInstance().getText("components.monitoring.not_enabled"));
+			throw new IllegalStateException(Prop.getInstance().getText("components.monitor.disabled.performance"));
 
 		List<ExecutionEntry> stats = new ArrayList<>(executionDurations.values());
 		Collections.sort(stats);


### PR DESCRIPTION
Opravené nasledujúce chyby:

- Deepl 429 too many requests, ak navrátený response pri preklade hlási chybu 429, pridá sa oneskorenie a request sa zopakuje X krát podľa nastavenej konštanty (čas sa inkrementuje)

- pridanie automatického prekladu perexu anotácia (html_data) pri klonovaní a prekladaní štruktúry

- fix prekaldania INCLUDE časti v stránke (doc), parsujú sa von, stránka sa preloží a INCLUDE časti sa vložia naspäť