### PR TITLE
Feature/57665 potvrdenie odhlasenia z newslettru

### DIFF
--- a/src/main/webapp/components/dmail/unsubscribe.jsp
+++ b/src/main/webapp/components/dmail/unsubscribe.jsp
@@ -45,12 +45,13 @@
 
 	// Unsubscribe z mailingu
 	if (dmspID > 0) {
-        Sender.debugin();
 		String emailDmsp = EmailDB.getEmail(dmspID);
 		boolean saveOK = EmailDB.addUnsubscribedEmail(emailDmsp);
 
 		if (saveOK) {
 			request.setAttribute("unsubscribeSuccess", prop.getText("dmail.unsubscribe.emailunsubscribed", emailDmsp));
+			request.setAttribute("unsubscribeSuccess-showUndelete", "true");
+
 		} else {
 			request.setAttribute("unsubscribeErrors", prop.getText("dmail.unsubscribe.error_unsubscribe_email"));
 		}
@@ -70,7 +71,7 @@
 		    String unsubscribedUrl = safeHref + "/newsletter/odhlasenie-z-newsletra.html?" + Constants.getString("dmailStatParam") + "=" + hash;
 
 		    String fromName = "WebjetCMS";
-		    String fromEmail = "tvoj@email.sk";
+		    String fromEmail = "tester@balat.sk";
 		    String toEmail = email;
 		    String subject = "Overenie mailu pre odhlásenie";
 		    String message = prop.getText("dmail.unsubscribe.bodyNew", unsubscribedUrl);

--- a/src/test/webapp/tests/apps/dmail/unsubscribed-approval.js
+++ b/src/test/webapp/tests/apps/dmail/unsubscribed-approval.js
@@ -43,7 +43,8 @@ Scenario('Preparation - create random subscribers', ({ I, DT, DTE }) => {
 });
 
 
-Scenario('Test unsubscribe text - default, empty, edited', async ({ Apps, DTE, I }) => {
+Scenario('Test unsubscribe text - default, empty, edited', async ({ Apps, DTE, I, TempMail }) => {
+
     await setUnsubscribeText(Apps, DTE, I, defaultText);
 
     I.amOnPage('/newsletter/odhlasenie-z-newsletra.html');
@@ -52,6 +53,8 @@ Scenario('Test unsubscribe text - default, empty, edited', async ({ Apps, DTE, I
     I.seeElement(locate('a').withText('Nie, chcem zostať'));
     I.see(defaultText);
     I.click(locate('.bSubmit').withAttr({'value':'Odhlásiť sa z odberu'}));
+    I.waitForText("Bol Vám zaslaný e-mail, v ktorom prosím potvrďte Vašu voľbu.");
+    await handleTempMailSubmission(I, TempMail);
     I.waitForElement(locate('fieldset > .alert.alert-success').withText('Email úspešne odhlásený.'), 10);
 
     await setUnsubscribeText(Apps, DTE, I, '');
@@ -61,6 +64,8 @@ Scenario('Test unsubscribe text - default, empty, edited', async ({ Apps, DTE, I
     I.dontSeeElement(locate('a').withText('Nie, chcem zostať'));
     I.dontSee(defaultText);
     I.click(locate('.bSubmit').withAttr({'value':'Odhlásiť sa z odberu'}));
+    I.waitForText("Bol Vám zaslaný e-mail, v ktorom prosím potvrďte Vašu voľbu.");
+    await handleTempMailSubmission(I, TempMail);
     I.waitForElement(locate('fieldset > .alert.alert-success').withText('Email úspešne odhlásený.'), 10);
 
     await setUnsubscribeText(Apps, DTE, I, changedText);
@@ -111,6 +116,8 @@ Scenario('Email - unsubscribe with confirmation', async ({ I, Document, TempMail
     I.seeElement(locate('a').withText('Nie, chcem zostať'));
     I.seeElement(locate('input#unsubscribeEmail').withAttr({'readonly':'readonly'}));
     I.click(locate('.bSubmit').withAttr({'value':'Odhlásiť sa z odberu'}));
+    I.waitForText("Bol Vám zaslaný e-mail, v ktorom prosím potvrďte Vašu voľbu.");
+    await handleTempMailSubmission(I, TempMail);
     I.waitForText('Email úspešne odhlásený.', 10);
 });
 
@@ -161,6 +168,14 @@ Scenario('Revert - remove autotest subscribers and set default unsubscribe text'
 
     await setUnsubscribeText(Apps, DTE, I, defaultText);
 });
+
+async function handleTempMailSubmission(I, TempMail) {
+    TempMail.login(randomName_1);
+    TempMail.openLatestEmail();
+    I.waitForElement('#info > div > p > a[href*="newsletter/odhlasenie"]', 10);
+    const url = await I.grabTextFrom('#info > div > p > a[href*="newsletter/odhlasenie"]');
+    I.amOnPage(url.replace("https", "http"));
+}
 
 async function setConfirmation(Apps, DTE, I, shouldBeChecked ){
     I.closeOtherTabs();

--- a/src/webjet8/java/sk/iway/iwcm/dmail/EmailDB.java
+++ b/src/webjet8/java/sk/iway/iwcm/dmail/EmailDB.java
@@ -344,6 +344,56 @@ public class EmailDB
 		return email;
 	}
 
+    /**
+	 * Vrati emailId pre zadane email z tabulky emails
+	 * @param email
+	 * @return
+	 */
+    public static Integer getEmailId(String email)
+    {
+        Integer emailId = null;
+
+        Connection db_conn = null;
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+
+        try
+        {
+            db_conn = DBPool.getConnection();
+            ps = db_conn.prepareStatement(
+                "SELECT email_id FROM emails WHERE recipient_email=? AND domain_id=?"
+            );
+            ps.setString(1, email);
+            ps.setInt(2, CloudToolsForCore.getDomainId());
+
+            rs = ps.executeQuery();
+
+            if (rs.next())
+            {
+                emailId = rs.getInt("email_id");
+            }
+        }
+        catch (Exception ex)
+        {
+            sk.iway.iwcm.Logger.error(ex);
+        }
+        finally
+        {
+            try
+            {
+                if (rs != null) rs.close();
+                if (ps != null) ps.close();
+                if (db_conn != null) db_conn.close();
+            }
+            catch (Exception ex2)
+            {
+                sk.iway.iwcm.Logger.error(ex2);
+            }
+        }
+
+        return emailId;
+    }
+
 	/**
 	 * Vymaze odhlasene emaily z danej kampane, je potrebne vykonat pred znovaspustenim kampane
 	 * @param campaignId

--- a/src/webjet8/java/sk/iway/iwcm/dmail/Sender.java
+++ b/src/webjet8/java/sk/iway/iwcm/dmail/Sender.java
@@ -821,7 +821,7 @@ public class Sender extends TimerTask
 	 * @param emailId
 	 * @return
 	 */
-	private static String getClickHash(int emailId) {
+	public static String getClickHash(int emailId) {
 		String hash = (new SimpleQuery()).forString("SELECT click_hash FROM emails WHERE email_id=?", emailId);
 		if (Tools.isEmpty(hash)) {
 			hash = String.valueOf(emailId) + Password.generateStringHash(16);


### PR DESCRIPTION
Jakub: toto bude uz komplikovanejsia uprava, ked tak popros Sebastiana aby ti s tym pomohol. Potrebujeme nejako verifikovat odhlasenie z newsletra, tam sa uz robilo niekolko uprav pri prihlasovani. Ked prides na tuto stranku priamo:

https://demo.webjetcms.sk/newsletter/odhlasenie-z-newsletra.html

tak mozes zadat lubovolny email na odhlasenie (aj cudzi) a my ho odhlasime. V odoslanom newsletri je standardne odkaz, ktory obsahuje aj URL parameter ?webjetDmsp=XXX na zaklade ktoreho verifikujeme platnost emailu. Ak ale prides priamo, tak neriesime nic a odhlasime.

Navrhujem preto doplnit funkciu double-opt-out. Cize ked prides BEZ URL PARAMETRA webjetDmsp, tak vtedy sa po zadani emailu musi vygenerovat email na danu adresu v ktorom pouzivatel musi kliknut na linku pre potvrdenie odhlasenia. Technicky to treba spravit tak, ze sa odosle email cez system hromadneho emailu, aby do odkazu doplnil ten ?webjetDmsp=XXX a potom fungovalo odhlasenie.

Cize zhrniem:

Prides priamo sem zadanim do prehliadaca: https://demo.webjetcms.sk/newsletter/odhlasenie-z-newsletra.html
Zadas email adresu na odhlasenie
Na danu email adresu sa posle potvrdenie na odhlasenie (texty cez prekladove kluce), bude tam odkaz Potvrdit odhlasenie s odkazom na rovnaku stranku. Tu musite vymysliet ako to spravit, email sa nemoze odoslat cez SendMail.send, ale musi sa zapisat do emails tabulky a odoslat cez Sender. MALO BY TO IST same, ak to spravite pomocou SendMail.sendLater - ten email zapise do DB tabulky emails a odosle ako hromadny email. POZOR ale, ked si v Sender pozriete ako sa pouziva metoda addClickInfo tak sa to doplni len ked je vyplnene aj URL, cize do volanie sendLater je potrebne spravne vyplnit baseHref (co bude URL adresa tej stranky). Ak je vyplnene telo emailu tak sa pouzije, ak by bolo prazdne, tak WebJET stiahne stranu na danom baseHref ako text.
Spatlat to treba cele do unsubscribe.jsp, tam si to sprav ale ako volanie triedy. Cele sa to sialene deje upodminkovane okolo if (Tools.isNotEmpty(email) && ( (dmspID > 0 && confirmUnsubscribe==false) || ("true".equals(request.getParameter("save"))) ) ). Tu nastava situacia, ze dmspID<0, pre tento pripad to posle email a vypise, ze na zadanu email adresu bolo odoslane potvrdenie odhlasenia.