### PR TITLE
[54273-72] fix: quill - support for UL html element

### DIFF
--- a/docs/sk/CHANGELOG-2025.md
+++ b/docs/sk/CHANGELOG-2025.md
@@ -8,6 +8,8 @@
 
 > Opravná verzia pôvodnej verzie 2025.0.
 
+!> **Upozornenie:** možná zmena správania polí typu `quill` pre odrážkový zoznam v dátových tabuľkách (#54273-72).
+
 - PDF - opravené nastavenie cesty do `fonts` priečinka s písmami. Je potrebné zadať plnú cestu na disku servera (#57657).
 - Aktualizovaná knižnica `Apache Commons BeanUtils` na verziu 1.11.0.
 - Inicializácia - doplnená kontrola existencie súboru `autoupdate.xml`, aby na verejných uzloch clustra nepísalo chybu pri štarte WebJETu (#54273-68).
@@ -21,6 +23,7 @@
 - Dátové tabuľky / vyhľadávanie v administrácii - povolené špeciálne znaky (napr. úvodzovky) pre vyhľadávanie v dátových tabuľkách (#54273-70).
 - Formuláre - schované zbytočné tlačidlo na vytvorenie nového záznamu v zozname vyplnených formulárov (#54273-70).
 - Webové stránky - doplnená možnosť vkladať HTML kód do názvov priečinkov ako napríklad `WebJET<sup>TM</sup>` - v zozname webových stránok sa z dôvodu bezpečnosti HTML kód nevykoná, ale v aplikáciach ako Menu a navigačná lišta sa HTML kód zobrazí korektne a vykoná sa. Dôležitá podmienka je, aby kód obsahoval uzatváraciu značku `</...>`. HTML kód je odstránený aj z automaticky generovanej URL adresy. Povolený je len bezpečný HTML kód povolený v triede `AllowSafeHtmlAttributeConverter` (#54273-70).
+- Dátové tabuľky - pre polia typu malý HTML editor (`quill`) **upravené správanie pre odrážkový zoznam** (HTML značka `ul`). Pôvodný editor nastavoval pre tento prípad na `li` elemente atribút `data-list="bullet"` a nedokázal použiť priamo `ul` element namiesto `ol` elementu. Nové správanie používa korektnú HTML značku `ul` a odstraňuje nepotrebný atribút `data-list="bullet"` (#54273-72).
 
 ## 2025.0.23
 

--- a/src/main/java/sk/iway/iwcm/system/jpa/AllowSafeHtmlAttributeConverter.java
+++ b/src/main/java/sk/iway/iwcm/system/jpa/AllowSafeHtmlAttributeConverter.java
@@ -63,7 +63,8 @@ public class AllowSafeHtmlAttributeConverter implements AttributeConverter<Strin
          .allowUrlProtocols("http", "https", "data")
          .allowAttributes("href").onElements("a")
          .allowAttributes("src", "alt", "title").onElements("img")
-         .allowAttributes("class").onElements("a", "img", "div", "span", "p", "h1", "h2", "h3", "h4", "h5", "h6", "i", "b", "strong", "em")
+         .allowAttributes("class").onElements("a", "img", "div", "span", "p", "h1", "h2", "h3", "h4", "h5", "h6", "i", "b", "strong", "em", "li", "ul", "ol", "blockquote", "table", "tr", "td", "th", "thead", "tbody", "tfoot", "br")
+         .allowAttributes("data-list").onElements("li") //quill editor support for lists
          .toFactory();
       String safeHTML = policy.sanitize(unsafeHtml);
       safeHTML = Tools.replace(safeHTML, Constants.NON_BREAKING_SPACE, "&nbsp;");

--- a/src/main/webapp/admin/v9/npm_packages/webjetdatatables/field-type-quill.js
+++ b/src/main/webapp/admin/v9/npm_packages/webjetdatatables/field-type-quill.js
@@ -52,6 +52,7 @@ export function typeQuill() {
         //FIX: ak do style elementu pridame aj color, tak quill zachova cely span element (inak ho zmaze)
         //pridame to ako prve, ak by tam bolo dalsie color:nieco
         htmlCode = htmlCode.replace(/ style="/gi, ' style="color:inherit;');
+        htmlCode = htmlCode.replace(/color:inherit;color:inherit;/gi, 'color:inherit;');
 
         let $html = $("<section>"+htmlCode+"</section>");
         //append data-list to LI elements depending on OL or UL parent
@@ -93,6 +94,8 @@ export function typeQuill() {
     window.quillToHtmlFormat = function(htmlCode) {
         //remove <span class="ql-ui" contenteditable="false"> from the HTML code
         htmlCode = htmlCode.replace(/<span class="ql-ui" contenteditable="false"><\/span>/gi, '');
+        //remove color:inherit; from the HTML code
+        htmlCode = htmlCode.replace(/color:inherit;/gi, '');
 
         //replace <ol><li data-list="bullet"> with <ul>
         let $html = $("<section>"+htmlCode+"</section>");

--- a/src/main/webapp/admin/v9/npm_packages/webjetdatatables/field-type-quill.js
+++ b/src/main/webapp/admin/v9/npm_packages/webjetdatatables/field-type-quill.js
@@ -46,8 +46,8 @@ export function typeQuill() {
         htmlCode = htmlCode.replace(/<\/div>/gi, "</p>");
 
         //nahrad inline styl za tagy em a strong
-        htmlCode = htmlCode.replace(/<span[^<>]+style="font-style:italic">([^<>]+)<\/span>/gi, '<em>$&</em>');
-        htmlCode = htmlCode.replace(/<span[^<>]+style="font-weight:bold">([^<>]+)<\/span>/gi, '<strong>$&</strong>');
+        htmlCode = htmlCode.replace(/<span[^<>]+style="font-style:italic">([^<>]+)<\/span>/gi, '<em>$1</em>');
+        htmlCode = htmlCode.replace(/<span[^<>]+style="font-weight:bold">([^<>]+)<\/span>/gi, '<strong>$1</strong>');
 
         //FIX: ak do style elementu pridame aj color, tak quill zachova cely span element (inak ho zmaze)
         //pridame to ako prve, ak by tam bolo dalsie color:nieco

--- a/src/main/webapp/admin/v9/npm_packages/webjetdatatables/field-type-quill.js
+++ b/src/main/webapp/admin/v9/npm_packages/webjetdatatables/field-type-quill.js
@@ -31,6 +31,106 @@ export function typeQuill() {
 
     ];
 
+    /**
+     * Update HTML to quill supported HTML tags, e.g.:
+     * ol-li.bullet -> ul.li
+     * @param {String} html
+     */
+    window.quillFromHtmlFormat = function(htmlCode) {
+        //console.log("QUILL SET, htmlCode=", htmlCode);
+        if (htmlCode == null || htmlCode=="") htmlCode = "<p><br/></p>";
+        if (htmlCode.indexOf("<p")==-1 && htmlCode.indexOf("<h")==-1 && htmlCode.indexOf("<div")==-1) htmlCode = "<p>"+htmlCode+"</p>";
+
+        //aktualna verzia pracuje s P elementami namiesto DIV elementov, musime upravit povodny zapis
+        htmlCode = htmlCode.replace(/<div>/gi, "<p>");
+        htmlCode = htmlCode.replace(/<\/div>/gi, "</p>");
+
+        //nahrad inline styl za tagy em a strong
+        htmlCode = htmlCode.replace(/<span[^<>]+style="font-style:italic">([^<>]+)<\/span>/gi, '<em>$&</em>');
+        htmlCode = htmlCode.replace(/<span[^<>]+style="font-weight:bold">([^<>]+)<\/span>/gi, '<strong>$&</strong>');
+
+        //FIX: ak do style elementu pridame aj color, tak quill zachova cely span element (inak ho zmaze)
+        //pridame to ako prve, ak by tam bolo dalsie color:nieco
+        htmlCode = htmlCode.replace(/ style="/gi, ' style="color:inherit;');
+
+        let $html = $("<section>"+htmlCode+"</section>");
+        //append data-list to LI elements depending on OL or UL parent
+        $html.find("li").each(function () {
+            let $li = $(this);
+            if ($li.parent("ol").length > 0) {
+                $li.attr("data-list", "ordered");
+            } else if ($li.parent("ul").length > 0) {
+                $li.attr("data-list", "bullet");
+            }
+        });
+
+        //replace UL with OL if it has data-list="ordered"
+        $html.find("ul").each(function () {
+            let $ul = $(this);
+
+            //save all attributes from ul to ol
+            let ulAttrs = $ul[0].attributes;
+            let $ol = $("<ol>");
+            for (let i = 0; i < ulAttrs.length; i++) {
+                let attr = ulAttrs[i];
+                $ol.attr(attr.name, attr.value);
+            }
+
+            $ul.replaceWith(function () {
+                return $ol.append($(this).contents());
+            });
+        });
+
+        htmlCode = $html.html();
+        return htmlCode;
+    }
+
+    /**
+     * Update HTML from quill to standard HTML tags, e.g.:
+     * ul.li -> ol-li.bullet
+     * @param {String} html
+     */
+    window.quillToHtmlFormat = function(htmlCode) {
+        //remove <span class="ql-ui" contenteditable="false"> from the HTML code
+        htmlCode = htmlCode.replace(/<span class="ql-ui" contenteditable="false"><\/span>/gi, '');
+
+        //replace <ol><li data-list="bullet"> with <ul>
+        let $html = $("<section>"+htmlCode+"</section>");
+        //console.log("htmlCode before ul fix=", $html.html());
+        $html.find("li").each(function () {
+            let $li = $(this);
+            if ($li.data("list") === "bullet") {
+                let $ol = $li.parent("ol");
+                if ($ol.length > 0) {
+                    //replace ol with ul
+
+                    //save all attributes from ol to ul
+                    let olAttrs = $ol[0].attributes;
+                    let $ul = $("<ul>");
+                    for (let i = 0; i < olAttrs.length; i++) {
+                        let attr = olAttrs[i];
+                        $ul.attr(attr.name, attr.value);
+                    }
+
+                    $ol.replaceWith(function () {
+                        return $ul.append($(this).contents());
+                    });
+                }
+            }
+        });
+
+        //remove data-list attribute from li elements
+        $html.find("li").each(function () {
+            let $li = $(this);
+            if ($li.data("list")) {
+                $li.removeAttr("data-list");
+            }
+        });
+
+        htmlCode = $html.html();
+        return htmlCode;
+    }
+
     return {
         create: function (conf) {
             //console.log("Creating quill editor");
@@ -114,26 +214,12 @@ export function typeQuill() {
             var htmlCode = conf._quill.root.innerHTML;
             //prazdny text povazuj za prazdny, aby nam fungovalo required field
             if ("<p><br></p>"==htmlCode || ""==conf._quill.getText()) htmlCode = "";
-            return htmlCode;
+
+            return window.quillToHtmlFormat(htmlCode);
         },
 
         set: function (conf, val) {
-            var htmlCode = val;
-            //console.log("QUILL SET, htmlCode=", htmlCode);
-            if (htmlCode == null || htmlCode=="") htmlCode = "<p><br/></p>";
-            if (htmlCode.indexOf("<p")==-1 && htmlCode.indexOf("<h")==-1 && htmlCode.indexOf("<div")==-1) htmlCode = "<p>"+htmlCode+"</p>";
-
-            //aktualna verzia pracuje s P elementami namiesto DIV elementov, musime upravit povodny zapis
-            htmlCode = htmlCode.replace(/<div>/gi, "<p>");
-            htmlCode = htmlCode.replace(/<\/div>/gi, "</p>");
-
-            //nahrad inline styl za tagy em a strong
-            htmlCode = htmlCode.replace(/<span[^<>]+style="font-style:italic">([^<>]+)<\/span>/gi, '<em>$&</em>');
-            htmlCode = htmlCode.replace(/<span[^<>]+style="font-weight:bold">([^<>]+)<\/span>/gi, '<strong>$&</strong>');
-
-            //FIX: ak do style elementu pridame aj color, tak quill zachova cely span element (inak ho zmaze)
-            //pridame to ako prve, ak by tam bolo dalsie color:nieco
-            htmlCode = htmlCode.replace(/ style="/gi, ' style="color:inherit;');
+            var htmlCode = quillFromHtmlFormat(val);
 
             //console.log("QUILL SET, FIXED htmlCode=", htmlCode);
             conf._quill.root.innerHTML = htmlCode;

--- a/src/main/webapp/admin/v9/npm_packages/webjetdatatables/quill.htmlEditButton.js
+++ b/src/main/webapp/admin/v9/npm_packages/webjetdatatables/quill.htmlEditButton.js
@@ -62,7 +62,10 @@ class htmlEditButton {
 }
 
 function launchPopupEditor(quill, options) {
-  const htmlFromEditor = quill.container.querySelector(".ql-editor").innerHTML;
+  let htmlFromEditor = quill.container.querySelector(".ql-editor").innerHTML;
+
+  htmlFromEditor = window.quillToHtmlFormat(htmlFromEditor);
+
   const popupContainer = $create("div");
   const overlayContainer = $create("div");
   const msg = options.msg || 'Edit HTML here, when you click "OK" the quill editor\'s contents will be replaced';
@@ -108,7 +111,7 @@ function launchPopupEditor(quill, options) {
   buttonOk.onclick = function() {
     const output = textArea.value.split(/\r?\n/g).map(el => el.trim());
     const noNewlines = output.join("");
-    quill.container.querySelector(".ql-editor").innerHTML = noNewlines;
+    quill.container.querySelector(".ql-editor").innerHTML =  window.quillFromHtmlFormat(noNewlines);
     document.body.removeChild(overlayContainer);
   };
 }
@@ -117,7 +120,7 @@ function launchPopupEditor(quill, options) {
 function formatHTML(code) {
   "use strict";
 
-  //webjet fix
+  //====================== webjet fix =======================
     //add new line to end p and div tag
     let blockTags = ["p", "div", "ul", "li", "ol", "h1", "h2", "h3", "h4", "h5", "h6", "blockquote", "pre", "table", "tr", "td", "th"];
     blockTags.forEach(tag => {
@@ -135,8 +138,13 @@ function formatHTML(code) {
     });
     //replace double new lines with single
     code = code.replace(/\n\n/g, "\n");
+
+    //remove OL helper classes
+    code = code.replace(/<span class="ql-ui" contenteditable="false"><\/span>/gi, '');
+
+    //DO NOT CONTINUE WITH THE OLD CODE BELOW
     if (1==1) return code;
-  //end webjet fix
+  //===================== end webjet fix =====================
 
   let stripWhiteSpaces = true;
   let stripEmptyLines = true;

--- a/src/test/webapp/tests/admin/datatable-field-types.js
+++ b/src/test/webapp/tests/admin/datatable-field-types.js
@@ -39,8 +39,8 @@ Scenario('type-quill-htmlview', async ({ I, DT, DTE }) => {
     htmlFromEditor = htmlFromEditor.replace(/\s+/g, ' ').trim();
     htmlFromEditor = htmlFromEditor.replace(/> </g, '><');
 
-    console.log("htmlEdit=", htmlFromEditor);
-    console.log("htmlCode=", htmlCode);
+    //console.log("htmlEdit=", htmlFromEditor);
+    //console.log("htmlCode=", htmlCode);
     //check that the HTML view is correct
     I.assertEqual(htmlFromEditor, htmlCode, "HTML view of quill editor is not correct");
 

--- a/src/test/webapp/tests/admin/datatable-field-types.js
+++ b/src/test/webapp/tests/admin/datatable-field-types.js
@@ -1,0 +1,50 @@
+Feature('admin.datatable-field-types');
+
+Before(({ I, login }) => {
+     login('admin');
+});
+
+
+/**
+ * Test HTML view of quill editor, test UL and OL tags
+ * Quill editor supports only UL and OL tags, so we need to test that
+ * the HTML view is correct and that we can edit it.
+ */
+Scenario('type-quill-htmlview', async ({ I, DT, DTE }) => {
+
+    let htmlCode = `<p>Specs:</p><ol><li>0-100 km/h in ~2.1 s</li><li>Up to 652 km range</li><li>Tri-motor all-wheel drive</li></ol><p>Features:</p><ul class="features"><li>Autopilot &amp; FSD Capability</li><li>17-inch Cinematic Touchscreen</li><li>Premium Interior</li></ul>`;
+
+    I.amOnPage("/apps/banner/admin/?id=7053");
+    DTE.waitForEditor("bannerDataTable");
+    I.clickCss("#pills-dt-bannerDataTable-advanced-tab");
+
+    I.click(locate("button").withChild(".ti-code"));
+
+    I.waitForElement(".ql-html-textContainer", 5);
+    I.fillField(".ql-html-textArea", htmlCode);
+    I.clickCss("button.ql-html-buttonOk");
+
+    DTE.save();
+
+    //open again the editor and check the HTML view
+    I.amOnPage("/apps/banner/admin/?id=7053");
+    DTE.waitForEditor("bannerDataTable");
+    I.clickCss("#pills-dt-bannerDataTable-advanced-tab");
+    I.click(locate("button").withChild(".ti-code"));
+
+    I.waitForElement(".ql-html-textContainer", 5);
+    let htmlFromEditor = await I.grabValueFrom(".ql-html-textArea");
+
+    //trim all spaces and new lines from the HTML code
+    htmlFromEditor = htmlFromEditor.replace(/\s+/g, ' ').trim();
+    htmlFromEditor = htmlFromEditor.replace(/> </g, '><');
+
+    console.log("htmlEdit=", htmlFromEditor);
+    console.log("htmlCode=", htmlCode);
+    //check that the HTML view is correct
+    I.assertEqual(htmlFromEditor, htmlCode, "HTML view of quill editor is not correct");
+
+    //test it on webpage
+    I.amOnPage("/apps/bannerovy-system/banner-system.html");
+    I.seeInSource(htmlCode);
+});

--- a/src/test/webapp/tests/admin/datatable-field-types.js
+++ b/src/test/webapp/tests/admin/datatable-field-types.js
@@ -12,7 +12,7 @@ Before(({ I, login }) => {
  */
 Scenario('type-quill-htmlview', async ({ I, DT, DTE }) => {
 
-    let htmlCode = `<p>Specs:</p><ol><li>0-100 km/h in ~2.1 s</li><li>Up to 652 km range</li><li>Tri-motor all-wheel drive</li></ol><p>Features:</p><ul class="features"><li>Autopilot &amp; FSD Capability</li><li>17-inch Cinematic Touchscreen</li><li>Premium Interior</li></ul>`;
+    let htmlCode = `<p><strong>Specs:</strong></p><ol><li>0-100 km/h in ~2.1 s</li><li>Up to <strong>652</strong> km range</li><li>Tri-motor all-wheel drive</li></ol><p><em>Features:</em></p><ul class="features"><li>Autopilot &amp; FSD Capability</li><li>17-inch <span style="color:rgb( 161 , 0 , 0 )">Cinematic</span> Touchscreen</li><li>Premium Interior</li></ul>`;
 
     I.amOnPage("/apps/banner/admin/?id=7053");
     DTE.waitForEditor("bannerDataTable");
@@ -39,8 +39,8 @@ Scenario('type-quill-htmlview', async ({ I, DT, DTE }) => {
     htmlFromEditor = htmlFromEditor.replace(/\s+/g, ' ').trim();
     htmlFromEditor = htmlFromEditor.replace(/> </g, '><');
 
-    //console.log("htmlEdit=", htmlFromEditor);
-    //console.log("htmlCode=", htmlCode);
+    console.log("htmlEdit=", htmlFromEditor);
+    console.log("htmlCode=", htmlCode);
     //check that the HTML view is correct
     I.assertEqual(htmlFromEditor, htmlCode, "HTML view of quill editor is not correct");
 


### PR DESCRIPTION
Ahoj, objavil som chybu v aplikacii  Bannerovy system v  editore bannera (Obsahovy banner)  v poli Popisný text
Z nejakeho dovodu ked vlizim text a zmenim ho na ul a ulozim banner a znova ho dam editovat tak sa ul zmeni na ol do li vlizi span a pred a za ol vlozi p
HTML zmeneho ul

```
<p><br></p>
<ol>
    <li><span class="ql-ui" contenteditable="false"></span>test</li>
    <li><span class="ql-ui" contenteditable="false"></span>test</li>
</ol>
<p><br></p>
```
