### PR TITLE
[57657-9] feat: add perex groups handling for perexGroupsRenderAsSelect in image editor and gallery

### DIFF
--- a/docs/sk/CHANGELOG-2025.md
+++ b/docs/sk/CHANGELOG-2025.md
@@ -25,6 +25,7 @@
 - Formuláre - schované zbytočné tlačidlo na vytvorenie nového záznamu v zozname vyplnených formulárov (#54273-70).
 - Webové stránky - doplnená možnosť vkladať HTML kód do názvov priečinkov ako napríklad `WebJET<sup>TM</sup>` - v zozname webových stránok sa z dôvodu bezpečnosti HTML kód nevykoná, ale v aplikáciach ako Menu a navigačná lišta sa HTML kód zobrazí korektne a vykoná sa. Dôležitá podmienka je, aby kód obsahoval uzatváraciu značku `</...>`. HTML kód je odstránený aj z automaticky generovanej URL adresy. Povolený je len bezpečný HTML kód povolený v triede `AllowSafeHtmlAttributeConverter` (#54273-70).
 - Dátové tabuľky - pre polia typu malý HTML editor (`quill`) **upravené správanie pre odrážkový zoznam** (HTML značka `ul`). Pôvodný editor nastavoval pre tento prípad na `li` elemente atribút `data-list="bullet"` a nedokázal použiť priamo `ul` element namiesto `ol` elementu. Nové správanie používa korektnú HTML značku `ul` a odstraňuje nepotrebný atribút `data-list="bullet"` (#54273-72).
+- Galéria - opravené zobrazenie perex skupín ak je ich viac ako 30 v galérii a editore obrázkov - zobrazené ako výberové pole. Opravené načítanie a uloženie skupín v editore obrázkov (#57657-9).
 
 ## 2025.0.23
 

--- a/src/main/java/sk/iway/iwcm/components/gallery/GalleryRestController.java
+++ b/src/main/java/sk/iway/iwcm/components/gallery/GalleryRestController.java
@@ -79,6 +79,7 @@ public class GalleryRestController extends DatatableRestControllerV2<GalleryEnti
                     entity.setUploadDatetime(new Date());
                     entity.setDomainId(CloudToolsForCore.getDomainId());
                 }
+                processFromEntity(entity, ProcessItemAction.EDIT);
             }
 
             if(entity.getId() == null) entity.setId(Long.valueOf(-1));
@@ -263,7 +264,7 @@ public class GalleryRestController extends DatatableRestControllerV2<GalleryEnti
             }
         }
 
-        return saved;
+        return processFromEntity(saved, ProcessItemAction.EDIT, 1);
     }
 
     @Override
@@ -279,7 +280,7 @@ public class GalleryRestController extends DatatableRestControllerV2<GalleryEnti
             if (FileTools.isFile(original.getImagePath()+"/s_"+original.getImageName())) FileTools.moveFile(original.getImagePath()+"/s_"+original.getImageName(), saved.getImagePath()+"/s_"+saved.getImageName());
         }
 
-        return saved;
+        return processFromEntity(saved, ProcessItemAction.EDIT, 1);
     }
 
     private void setLastModified(String path, long lastModified) {

--- a/src/main/java/sk/iway/iwcm/components/gallery/ImageEditorListener.java
+++ b/src/main/java/sk/iway/iwcm/components/gallery/ImageEditorListener.java
@@ -1,0 +1,40 @@
+package sk.iway.iwcm.components.gallery;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.ui.ModelMap;
+
+import sk.iway.iwcm.JsonTools;
+import sk.iway.iwcm.Logger;
+import sk.iway.iwcm.admin.ThymeleafEvent;
+import sk.iway.iwcm.components.perex_groups.PerexGroupsEntity;
+import sk.iway.iwcm.components.perex_groups.PerexGroupsRepository;
+import sk.iway.iwcm.system.datatable.OptionDto;
+import sk.iway.iwcm.system.spring.events.WebjetEvent;
+
+@Component
+public class ImageEditorListener {
+
+    @Autowired
+    private PerexGroupsRepository perexGroupsRepository;
+
+    @EventListener(condition = "#event.clazz eq 'sk.iway.iwcm.admin.ThymeleafEvent' && event.source.page=='image-editor'")
+    protected void setInitalData(final WebjetEvent<ThymeleafEvent> event) {
+        ModelMap model = event.getSource().getModel();
+
+        List<OptionDto> perexGroupsOptions = new java.util.ArrayList<>();
+        for(PerexGroupsEntity perex : perexGroupsRepository.findAllByOrderByPerexGroupNameAsc()) {
+            perexGroupsOptions.add(new OptionDto(perex.getPerexGroupName(), String.valueOf(perex.getId()), null));
+        }
+
+        try {
+            model.addAttribute("perexGroupsOptions", JsonTools.objectToJSON(perexGroupsOptions));
+        } catch (Exception e) {
+            Logger.error(ImageEditorListener.class, "Error setting initial data", e);
+            model.addAttribute("perexGroupsOptions", null);
+        }
+    }
+}

--- a/src/main/webapp/admin/v9/views/pages/apps/gallery.pug
+++ b/src/main/webapp/admin/v9/views/pages/apps/gallery.pug
@@ -124,6 +124,20 @@ block content
                         }
                     });
 
+                    if (window.perexGroupsRenderAsSelect===true) {
+                        window.WJ.DataTable.mergeColumns(columns, {
+                            name: "editorFields.perexGroupsIds",
+                            renderFormat: "dt-format-text",
+                            "editor" : {
+                                type : "select",
+                                multiple: true,
+                                attr: {
+                                    "data-multiple-separator": "\x0a\x0d"
+                                }
+                            }
+                        });
+                    }
+
                     //console.log(JSON.stringify(columns));
 
                     //console.log("tabsFolders", tabsFolders);
@@ -134,7 +148,7 @@ block content
                     if (typeof size == "undefined" || size == null) {
                         size = "S";
                     }
-                    
+
                     if (size != '') {
                         setDatatableInitSize(size);
                     };
@@ -172,7 +186,7 @@ block content
                         let arr = $("table.datatableInit");
                         for(let i = 0; i < arr.length; i++) {
                             //Skip searchTable (filter)
-                            if($(arr[i]).prop('id') != "jstreeSearchTable") 
+                            if($(arr[i]).prop('id') != "jstreeSearchTable")
                                 $(arr[i]).addClass('cardView cardView'+size);
                         }
                     }

--- a/src/main/webapp/admin/v9/views/pages/apps/image-editor.pug
+++ b/src/main/webapp/admin/v9/views/pages/apps/image-editor.pug
@@ -40,6 +40,28 @@ block content
             }
         ];
 
+
+        var customInitialData = dtWJ.getEmptyData(true);
+
+        let perexGroupsOptions = [(${perexGroupsOptions})];
+        customInitialData.options = {
+            "editorFields.perexGroupsIds": perexGroupsOptions
+        }
+
+        if (window.perexGroupsRenderAsSelect===true) {
+            window.WJ.DataTable.mergeColumns(columns, {
+                name: "editorFields.perexGroupsIds",
+                renderFormat: "dt-format-text",
+                "editor" : {
+                    type : "select",
+                    multiple: true,
+                    attr: {
+                        "data-multiple-separator": "\x0a\x0d"
+                    }
+                }
+            });
+        }
+
         window.domReady.add(function () {
             galleryTable = WJ.DataTable( {
                 url: url,
@@ -50,7 +72,7 @@ block content
                 fetchOnCreate: true,
                 fetchOnEdit: true,
                 idAutoOpener: true,
-                initialData: dtWJ.getEmptyData(true),
+                initialData: customInitialData,
                 onPreXhr: function(TABLE, e, settings, data) {
                     data.fixed_searchImagePath = imagePath;
                     data.fixed_searchImageName = imageName;
@@ -127,6 +149,12 @@ block content
                     }, 1000);
                     window.opener.elFinderInstance.exec('reload');
                 } catch (e) {console.log("Error reloading elfinder", e);}
+
+                if (imageEditorInstance == null) {
+                    setTimeout(() => {
+                        window.close();
+                    }, 1200);
+                }
             });
 
             $("#upload-wrapper .upload-wrapper-header").text(WJ.translate("components.image_editor.saving.js"));

--- a/src/test/webapp/tests/webpages/perex.js
+++ b/src/test/webapp/tests/webpages/perex.js
@@ -156,10 +156,21 @@ Scenario('Check Perex Groups Rendering Behavior in Editor', ({ I, DT, DTE , Docu
     Document.setConfigValue('perexGroupsRenderAsSelect', 3);
 
     checkElements(I, DTE, DT, false);
+});
+
+Scenario('Check Perex Groups Rendering Behavior in Gallery @current', ({ I, DT, DTE , Document }) => {
+
+    Document.setConfigValue('perexGroupsRenderAsSelect', 30);
+
+    checkGalleryElements(I, DTE, DT, true);
+
+    Document.setConfigValue('perexGroupsRenderAsSelect', 3);
+
+    checkGalleryElements(I, DTE, DT, false);
 
 });
 
-Scenario('Restore Default Perex Groups Rendering Configuration', ({ I, DT, Document }) => {
+Scenario('Restore Default Perex Groups Rendering Configuration @current', ({ I, DT, Document }) => {
     Document.setConfigValue('perexGroupsRenderAsSelect', 30);
     I.amOnPage('/admin/v9/webpages/web-pages-list/');
     DT.resetTable();
@@ -208,6 +219,26 @@ async function checkElements(I, DTE, DT, shouldSeeCheckbox) {
         I.dontSeeElement('#DTE_Field_perexGroups_0');
         I.see("podnikanie", ".DTE_Field_Name_perexGroups div.bootstrap-select .filter-option .filter-option-inner-inner");
         I.dontSee("investícia", ".DTE_Field_Name_perexGroups div.bootstrap-select .filter-option .filter-option-inner-inner");
+    }
+
+    DTE.cancel();
+}
+
+function checkGalleryElements(I, DTE, DT, shouldSeeCheckbox) {
+    I.amOnPage('/admin/v9/apps/gallery/?dir=/images/gallery/test-vela-foto/&id=236');
+    DTE.waitForEditor("galleryTable");
+    I.clickCss("#pills-dt-galleryTable-metadata-tab");
+
+    if (shouldSeeCheckbox) {
+        I.say('Check if I see checkbox in perex tab');
+        I.dontSeeElement('#DTE_Field_editorFields-perexGroupsIds[multiple]');
+        I.dontSeeElement('#DTE_Field_editorFields-perexGroupsIds');
+        I.seeElement('#DTE_Field_editorFields-perexGroupsIds_0');
+    } else {
+        I.say('Check if I see multiselect in perex tab');
+        I.seeElement('#DTE_Field_editorFields-perexGroupsIds[multiple]');
+        I.seeElement('#DTE_Field_editorFields-perexGroupsIds');
+        I.dontSeeElement('#DTE_Field_editorFields-perexGroupsIds_0');
     }
 
     DTE.cancel();


### PR DESCRIPTION
Prosím o co nejrychlejší upravení perexových skupin v Metadatech obrázků v Galereii stejně jako to je ve Webstránkách, tzn. když je jich hodně, tak aby se z toho udělalo multiselect pole. Na xxx.cz jich mají strašně moc a odsouvá to další pole zejména Autora strašně daleko dolů a rolování strašně zdržuje. Pokud by to mělo trvat déle, tak alespoň zatím přehodit pořadí a dát ty skupiny na konec, protože je zde momentálně vůbec nepoužívají.