### PR TITLE
feature/58093-ai-audit-prava-statistika

### DIFF
--- a/src/main/java/sk/iway/iwcm/admin/layout/LayoutService.java
+++ b/src/main/java/sk/iway/iwcm/admin/layout/LayoutService.java
@@ -116,6 +116,17 @@ public class LayoutService
                     css.append(".noperms-ver-pro { display: none !important; }\n");
                     javascript.append("nopermsJavascript[\"ver-pro\"]=true;\n");
                 }
+
+                //ve need to verify this modules because they are used in FE components
+                //and if user has no perms for them, they should not be visible in admin
+                String[] modulesToCheck = {"cmp_ai_tools", "cmp_ai_stats", "cmp_ai_button"};
+                for (String modKey : modulesToCheck) {
+                    if (user.isEnabledItem(modKey) == false) {
+                        String modName = Tools.replace(modKey, ".", "_");
+                        css.append(".noperms-").append(modName).append(" { display: none !important; }\n");
+                        javascript.append("nopermsJavascript[\"").append(modName).append("\"]=true;\n");
+                    }
+                }
             } catch (Exception ex) {
                 Logger.error(LayoutService.class, ex);
             }

--- a/src/main/java/sk/iway/iwcm/components/ai/rest/AssistantController.java
+++ b/src/main/java/sk/iway/iwcm/components/ai/rest/AssistantController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import sk.iway.iwcm.Adminlog;
+import sk.iway.iwcm.Identity;
 import sk.iway.iwcm.RequestBean;
 import sk.iway.iwcm.Tools;
 import sk.iway.iwcm.common.UploadFileTools;
@@ -29,13 +30,14 @@ import sk.iway.iwcm.components.ai.jpa.AssistantDefinitionRepository;
 import sk.iway.iwcm.components.ai.stat.jpa.AiStatRepository;
 import sk.iway.iwcm.system.datatable.json.DataTableAi;
 import sk.iway.iwcm.system.datatable.json.DataTableColumn;
+import sk.iway.iwcm.users.UsersDB;
 
 /**
  * REST controller for AI assistants - handles XHR requests from UI
  */
 @RestController
 @RequestMapping("/admin/rest/ai/assistant/")
-@PreAuthorize("@WebjetSecurityService.isAdmin()") //AI assistants can be in any module, so check just for admin perms
+@PreAuthorize("@WebjetSecurityService.hasPermission('cmp_ai_button')")
 public class AssistantController {
 
     private final AiService aiService;
@@ -182,8 +184,11 @@ public class AssistantController {
         column.setName(fieldName);
         column.setRenderFormat(renderFormat);
 
-        List<DataTableAi> ai = AiService.getAiAssistantsForField(fieldName, javaClassName, column, sk.iway.iwcm.i18n.Prop.getInstance(request));
-        column.setAi(ai); //set also to column for future use
+        Identity user = UsersDB.getCurrentUser(request);
+        if (user != null && user.isEnabledItem("cmp_ai_button")) {
+            List<DataTableAi> ai = AiService.getAiAssistantsForField(fieldName, javaClassName, column, sk.iway.iwcm.i18n.Prop.getInstance(request));
+            column.setAi(ai); //set also to column for future use
+        }
 
         return column;
     }

--- a/src/main/java/sk/iway/iwcm/components/ai/rest/AssistantController.java
+++ b/src/main/java/sk/iway/iwcm/components/ai/rest/AssistantController.java
@@ -184,11 +184,8 @@ public class AssistantController {
         column.setName(fieldName);
         column.setRenderFormat(renderFormat);
 
-        Identity user = UsersDB.getCurrentUser(request);
-        if (user != null && user.isEnabledItem("cmp_ai_button")) {
-            List<DataTableAi> ai = AiService.getAiAssistantsForField(fieldName, javaClassName, column, sk.iway.iwcm.i18n.Prop.getInstance(request));
-            column.setAi(ai); //set also to column for future use
-        }
+        List<DataTableAi> ai = AiService.getAiAssistantsForField(fieldName, javaClassName, column, sk.iway.iwcm.i18n.Prop.getInstance(request));
+        column.setAi(ai); //set also to column for future use
 
         return column;
     }

--- a/src/main/java/sk/iway/iwcm/components/ai/rest/AssistantController.java
+++ b/src/main/java/sk/iway/iwcm/components/ai/rest/AssistantController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import sk.iway.iwcm.Adminlog;
-import sk.iway.iwcm.Identity;
 import sk.iway.iwcm.RequestBean;
 import sk.iway.iwcm.Tools;
 import sk.iway.iwcm.common.UploadFileTools;
@@ -30,7 +29,6 @@ import sk.iway.iwcm.components.ai.jpa.AssistantDefinitionRepository;
 import sk.iway.iwcm.components.ai.stat.jpa.AiStatRepository;
 import sk.iway.iwcm.system.datatable.json.DataTableAi;
 import sk.iway.iwcm.system.datatable.json.DataTableColumn;
-import sk.iway.iwcm.users.UsersDB;
 
 /**
  * REST controller for AI assistants - handles XHR requests from UI

--- a/src/main/java/sk/iway/iwcm/system/Modules.java
+++ b/src/main/java/sk/iway/iwcm/system/Modules.java
@@ -202,6 +202,7 @@ public class Modules
 		modVersions.put("cmp_wiki", "EI;1c4"); //Wiki
 		modVersions.put("cmp_xml", "PEI;bf0");
 		modVersions.put("cmp_captcha", "PECI;a3c"); //zoznam slov pre captchu
+		modVersions.put("cmp_ai_tools", "PEI;109"); //zoznam slov pre AI tools
 
 		//modVersions.put("menuUsers", "PECDIO;f20"); //WebJET Multi-User Access - 2990 Sk, WebJET Protected Section-4990
 		modVersions.put("menuSync", "PEI;f36"); //WebJET Synchronization - 12900
@@ -294,13 +295,14 @@ public class Modules
 						m.setItemKey("cmp_"+file.getName());
 						m.setPath(baseDir+file.getName());
 						m.setUserItem(false);
+
+						//warning: this code is repated later after itemKey in prop file is read
 						wjPerms = modVersions.get(m.getItemKey());
 						if (wjPerms == null) wjPerms = "BPECIDMO";
 						m.setWjVersions(wjPerms);
 
 						String fileName = "modinfo.properties";
 						if (j>0) fileName = "modinfo"+j+".properties";
-
 						propFile = new IwcmFile(Tools.getRealPath(baseDir+file.getName()+"/"+fileName));
 						if (propFile.exists())
 						{
@@ -338,6 +340,13 @@ public class Modules
 							if (Tools.isNotEmpty(sTmp))
 							{
 								m.setItemKey(sTmp.trim());
+
+								//check perms for this new itemKey, if exists use it
+								String wjPermsNew = modVersions.get(m.getItemKey());
+								if (Tools.isNotEmpty(wjPermsNew)) {
+									wjPerms = wjPermsNew;
+									m.setWjVersions(wjPerms);
+								}
 							}
 							sTmp = prop.getProperty("menuOrder");
 							if (Tools.isNotEmpty(sTmp))

--- a/src/main/java/sk/iway/iwcm/system/Modules.java
+++ b/src/main/java/sk/iway/iwcm/system/Modules.java
@@ -415,7 +415,8 @@ public class Modules
 									if (Tools.isNotEmpty(sTmp)) subModule.setItemKey(sTmp.trim());
 
 									sTmp = prop.getProperty("leftSubmenu"+s+"DefaultDisabled");
-									if ("true".equals(sTmp) || m.isDefaultDisabled()) subModule.setDefaultDisabled(true);
+									if ("false".equals(sTmp)) subModule.setDefaultDisabled(false);
+									else if ("true".equals(sTmp) || m.isDefaultDisabled()) subModule.setDefaultDisabled(true);
 
 									sTmp = prop.getProperty("leftSubmenu"+s+"Icon");
 									if (Tools.isNotEmpty(sTmp)) subModule.setMenuIcon(sTmp.trim());

--- a/src/main/java/sk/iway/iwcm/system/datatable/json/DataTableColumn.java
+++ b/src/main/java/sk/iway/iwcm/system/datatable/json/DataTableColumn.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import lombok.Setter;
 import sk.iway.iwcm.Constants;
+import sk.iway.iwcm.Identity;
 import sk.iway.iwcm.InitServlet;
 import sk.iway.iwcm.Logger;
 import sk.iway.iwcm.RequestBean;
@@ -29,6 +30,7 @@ import sk.iway.iwcm.components.ai.rest.AiService;
 import sk.iway.iwcm.i18n.Prop;
 import sk.iway.iwcm.system.datatable.DataTableColumnType;
 import sk.iway.iwcm.system.datatable.DataTableColumnsFactory;
+import sk.iway.iwcm.users.UsersDB;
 
 /**
  * Trieda pre generovanie JSONu pre DataTable {@see https://datatables.net/} z
@@ -88,6 +90,7 @@ public class DataTableColumn {
         if (requestAttributes==null) return;
 
         HttpServletRequest request = requestAttributes.getRequest();
+        Identity user = UsersDB.getCurrentUser(request);
         Prop prop = Prop.getInstance(request);
 
         setPropertiesFromFieldType(field);
@@ -99,7 +102,7 @@ public class DataTableColumn {
         addEditIcon(field);
 
         //we need this to be last because it uses this.className, this.renderType etc
-        setAiPropertiesFromField(controller, field, prop);
+        setAiPropertiesFromField(controller, field, prop, user);
     }
 
     private void setPropertiesFromFieldType(Field field) {
@@ -327,8 +330,10 @@ public class DataTableColumn {
     }
 
     @SuppressWarnings("rawtypes")
-    private void setAiPropertiesFromField(Class controller, Field field, Prop prop) {
-        ai = AiService.getAiAssistantsForField(field.getName(), controller.getName(), this, prop);
+    private void setAiPropertiesFromField(Class controller, Field field, Prop prop, Identity user) {
+        if (user.isEnabledItem("cmp_ai_button")) {
+            ai = AiService.getAiAssistantsForField(field.getName(), controller.getName(), this, prop);
+        }
     }
 
     /**

--- a/src/main/java/sk/iway/iwcm/system/datatable/json/DataTableColumn.java
+++ b/src/main/java/sk/iway/iwcm/system/datatable/json/DataTableColumn.java
@@ -331,7 +331,7 @@ public class DataTableColumn {
 
     @SuppressWarnings("rawtypes")
     private void setAiPropertiesFromField(Class controller, Field field, Prop prop, Identity user) {
-        if (user.isEnabledItem("cmp_ai_button")) {
+        if (user != null && user.isEnabledItem("cmp_ai_button")) {
             ai = AiService.getAiAssistantsForField(field.getName(), controller.getName(), this, prop);
         }
     }

--- a/src/main/webapp/WEB-INF/classes/text-webjet9.properties
+++ b/src/main/webapp/WEB-INF/classes/text-webjet9.properties
@@ -2392,5 +2392,4 @@ components.ai_assistants.editor.replaceMode.replace=Nahradiť
 components.ai_assistants.editor.replaceMode.replace.tooltip=Nahradiť celý obsah poľa novým textom.
 components.ai_assistants.editor.continueChat.js=Pokračovať
 components.ai_assistants.editor.image_generation.no_images.js=Neboli vytvorené žiadne obrázky, skúste zmeniť inštrukcie.
-
-components.ai_assistants.button.title=Zobraziť AI tlačidlo v používateľskom rozhraní
+components.ai_assistants.button.title=AI tlačidlo v používateľskom rozhraní

--- a/src/main/webapp/WEB-INF/classes/text-webjet9.properties
+++ b/src/main/webapp/WEB-INF/classes/text-webjet9.properties
@@ -2392,3 +2392,5 @@ components.ai_assistants.editor.replaceMode.replace=Nahradiť
 components.ai_assistants.editor.replaceMode.replace.tooltip=Nahradiť celý obsah poľa novým textom.
 components.ai_assistants.editor.continueChat.js=Pokračovať
 components.ai_assistants.editor.image_generation.no_images.js=Neboli vytvorené žiadne obrázky, skúste zmeniť inštrukcie.
+
+components.ai_assistants.button.title=Zobraziť AI tlačidlo v používateľskom rozhraní

--- a/src/main/webapp/WEB-INF/classes/text_cz-webjet9.properties
+++ b/src/main/webapp/WEB-INF/classes/text_cz-webjet9.properties
@@ -2392,3 +2392,4 @@ components.ai_assistants.editor.replaceMode.replace=Nahradit
 components.ai_assistants.editor.replaceMode.replace.tooltip=Nahradit celý obsah pole novým textem.
 components.ai_assistants.editor.continueChat.js=Pokračovat
 components.ai_assistants.editor.image_generation.no_images.js=Nebyly vytvořeny žádné obrázky, zkuste změnit instrukce.
+components.ai_assistants.button.title=AI tlačítko v uživatelském rozhraní

--- a/src/main/webapp/WEB-INF/classes/text_en-webjet9.properties
+++ b/src/main/webapp/WEB-INF/classes/text_en-webjet9.properties
@@ -2392,3 +2392,4 @@ components.ai_assistants.editor.replaceMode.replace=Replace
 components.ai_assistants.editor.replaceMode.replace.tooltip=Replace the entire contents of the field with new text.
 components.ai_assistants.editor.continueChat.js=Continue
 components.ai_assistants.editor.image_generation.no_images.js=No images were generated, try changing the instructions.
+components.ai_assistants.button.title=AI button in user interface

--- a/src/main/webapp/admin/v9/npm_packages/webjetdatatables/editor-ai.js
+++ b/src/main/webapp/admin/v9/npm_packages/webjetdatatables/editor-ai.js
@@ -57,6 +57,11 @@ export class EditorAi {
      * Binds AI-related buttons to the provided EDITOR instance.
      */
     bindEditorButtons() {
+        if (WJ.hasPermission("cmp_ai_button") === false) {
+            //user does not have permission to see AI button
+            return;
+        }
+
         //console.log("Binding editor buttons, editor=", this.EDITOR);
 
         //iterate over EDITOR.TABLE.DATA.columns[].ai fields and generate AI button
@@ -117,16 +122,20 @@ export class EditorAi {
         let inputFields = $(".ai-field");
         inputFields.each((index, element) => {
             let inputField = $(element);
+            if (WJ.hasPermission("cmp_ai_button") === false) {
+                //user does not have permission to see AI button
+                inputField.removeClass("ai-field");
+            } else {
+                //if it doesnt have input-group, wrap it
+                if (inputField.parents(".input-group").length === 0) {
+                    inputField.wrap('<div class="input-group"></div>');
+                }
 
-            //if it doesnt have input-group, wrap it
-            if (inputField.parents(".input-group").length === 0) {
-                inputField.wrap('<div class="input-group"></div>');
-            }
-
-            //if it doesnt have ti-sparkles button add it
-            if (inputField.parents(".input-group").find(".ti-sparkles").length === 0) {
-                const button = this._getOtherButton(inputField);
-                inputField.parents(".input-group").append(button);
+                //if it doesnt have ti-sparkles button add it
+                if (inputField.parents(".input-group").find(".ti-sparkles").length === 0) {
+                    const button = this._getOtherButton(inputField);
+                    inputField.parents(".input-group").append(button);
+                }
             }
         });
     }

--- a/src/main/webapp/components/webjet9/modinfo3.properties
+++ b/src/main/webapp/components/webjet9/modinfo3.properties
@@ -11,11 +11,19 @@ group=config
 defaultDisabled=true
 hideSubmenu=false
 
-leftSubmenu1NameKey=components.ai_assistants.assistants.title
+leftSubmenu1NameKey=components.ai_assistants.instruction_tab
 leftSubmenu1Link=/admin/v9/settings/ai-assistants/
+leftSubmenu1UserItem=true
+leftSubmenu1ItemKey=cmp_ai_tools
 
 leftSubmenu2NameKey=components.ai_assistants.stats.title
 leftSubmenu2Link=/admin/v9/settings/ai-stats/
 leftSubmenu2ItemKey=cmp_ai_stats
 leftSubmenu2UserItem=true
 leftSubmenu2DefaultDisabled=true
+
+leftSubmenu3NameKey=components.ai_assistants.button.title
+leftSubmenu3Link=javascript:void();
+leftSubmenu3ItemKey=cmp_ai_button
+leftSubmenu3UserItem=true
+leftSubmenu3DefaultDisabled=false

--- a/src/main/webapp/components/webjet9/modinfo3.properties
+++ b/src/main/webapp/components/webjet9/modinfo3.properties
@@ -1,7 +1,7 @@
 
 leftMenuNameKey=components.ai_assistants.title
 itemKey=cmp_ai_tools
-userItem=true
+userItem=false
 menuOrder=7110
 leftMenuLink=/admin/v9/settings/ai-assistants/
 icon=sparkles
@@ -11,19 +11,23 @@ group=config
 defaultDisabled=true
 hideSubmenu=false
 
-leftSubmenu1NameKey=components.ai_assistants.instruction_tab
+leftSubmenu1NameKey=components.ai_assistants.assistants.title
 leftSubmenu1Link=/admin/v9/settings/ai-assistants/
-leftSubmenu1UserItem=true
 leftSubmenu1ItemKey=cmp_ai_tools
+leftSubmenu1UserItem=true
+leftSubmenu1DefaultDisabled=true
+leftSubmenu1Icon=message-chatbot
 
 leftSubmenu2NameKey=components.ai_assistants.stats.title
 leftSubmenu2Link=/admin/v9/settings/ai-stats/
 leftSubmenu2ItemKey=cmp_ai_stats
 leftSubmenu2UserItem=true
 leftSubmenu2DefaultDisabled=true
+leftSubmenu2Icon=chart-area-line
 
 leftSubmenu3NameKey=components.ai_assistants.button.title
 leftSubmenu3Link=javascript:void();
 leftSubmenu3ItemKey=cmp_ai_button
 leftSubmenu3UserItem=true
 leftSubmenu3DefaultDisabled=false
+leftSubmenu3Icon=sparkles

--- a/src/webjet8/java/sk/iway/iwcm/DBPool.java
+++ b/src/webjet8/java/sk/iway/iwcm/DBPool.java
@@ -157,7 +157,7 @@ public class DBPool
 							//riesene kvoli ING kde public node ma iny pripojovaci retazec
 							if (Tools.isNotEmpty(systemIwcmDBName) && systemIwcmDBName.equals(dbname))
 							{
-								Logger.println(DBPool.class, "Changing dbname from "+dbname+" to iwcm");
+								Logger.println(DBPool.class, "Changing dbname from "+dbname+" to iwcm, systemIwcmDBName="+systemIwcmDBName);
 								dbname = "iwcm";
 							}
 

--- a/src/webjet8/java/sk/iway/iwcm/grideditor/controller/GridEditorController.java
+++ b/src/webjet8/java/sk/iway/iwcm/grideditor/controller/GridEditorController.java
@@ -135,14 +135,14 @@ public class GridEditorController {
                 String templateDataDirPath = WriteTagToolsForCore.getCustomPath("/templates/"+tgroup.getDirectory()+"/dist/pagebuilder/", request);
                 if (FileTools.exists(templateDataDirPath))
                 {
-                    Logger.debug(GridEditorController.class, "getDataDirPath, returning "+templateDataDirPath);
+                    //Logger.debug(GridEditorController.class, "getDataDirPath, returning "+templateDataDirPath);
                     return templateDataDirPath;
                 }
                 //ak neexistuje dist, skus priamo pagebuilder adresar v sablone
                 templateDataDirPath = WriteTagToolsForCore.getCustomPath("/templates/"+tgroup.getDirectory()+"/pagebuilder/", request);
                 if (FileTools.exists(templateDataDirPath))
                 {
-                    Logger.debug(GridEditorController.class, "getDataDirPath, returning "+templateDataDirPath);
+                    //Logger.debug(GridEditorController.class, "getDataDirPath, returning "+templateDataDirPath);
                     return templateDataDirPath;
                 }
             }
@@ -150,7 +150,7 @@ public class GridEditorController {
 
         //ak neexistuju pre sablonu pouzi default
         String dataDirPath = WriteTagToolsForCore.getCustomPath("/components/grideditor/data/", request);
-        Logger.debug(GridEditorController.class, "getDataDirPath, returning "+dataDirPath);
+        //Logger.debug(GridEditorController.class, "getDataDirPath, returning "+dataDirPath);
         return dataDirPath;
     }
 
@@ -168,14 +168,14 @@ public class GridEditorController {
             {
                 String templateFavDirPath = WriteTagToolsForCore.getCustomPath("/files/protected/pagebuilder/"+tgroup.getDirectory()+"/", request);
                 //tu na rozdiel od citania pripravenych blokov netestujeme, ci adresar existuje, ak nie, tak ho ulozenie vytvori
-                Logger.debug(GridEditorController.class, "getFavouritesDirPath, returning "+templateFavDirPath);
+                //Logger.debug(GridEditorController.class, "getFavouritesDirPath, returning "+templateFavDirPath);
                 return templateFavDirPath;
             }
         }
 
         //ak neexistuju pre sablonu pouzi default
         String favDirPath = WriteTagToolsForCore.getCustomPath("/files/protected/grideditor/", request);
-        Logger.debug(GridEditorController.class, "getFavouritesDirPath, returning "+favDirPath);
+        //Logger.debug(GridEditorController.class, "getFavouritesDirPath, returning "+favDirPath);
         return favDirPath;
     }
 
@@ -620,25 +620,25 @@ public class GridEditorController {
      */
     private String getImagePath (String filePath, HttpServletRequest request){
 
-        Logger.debug(GridEditorController.class, "getImagePath, filePath="+filePath);
+        //Logger.debug(GridEditorController.class, "getImagePath, filePath="+filePath);
 
         // AK EXISTUJE JPG
         String path = filePath + ".jpg";
         IwcmFile img = new IwcmFile(Tools.getRealPath(path));
-        Logger.debug(GridEditorController.class, "getImagePath, testing jpg="+img.getAbsolutePath());
+        //Logger.debug(GridEditorController.class, "getImagePath, testing jpg="+img.getAbsolutePath());
         if (img.exists()) return path;
 
         // AK EXISTUJE PNG
         path = filePath + ".png";
         img = new IwcmFile(Tools.getRealPath(path));
-        Logger.debug(GridEditorController.class, "getImagePath, testing png="+img.getAbsolutePath());
+        //Logger.debug(GridEditorController.class, "getImagePath, testing png="+img.getAbsolutePath());
         if (img.exists()) return path;
 
 
         // AK EXISTUJE SVG
         path = filePath + ".svg";
         img = new IwcmFile(Tools.getRealPath(path));
-        Logger.debug(GridEditorController.class, "getImagePath, testing svg="+img.getAbsolutePath());
+        //Logger.debug(GridEditorController.class, "getImagePath, testing svg="+img.getAbsolutePath());
         if (img.exists()) return path;
 
         // AK NEEXISTUJE ANI JEDEN, vrat default obrazok


### PR DESCRIPTION
1. Audit - do auditu chcú zapisovať vstup aj výstup, čiže inputValue, userPrompt (ak je zadaný) a aj výstup, čiže čo AI odpovedala. Aby to nebolo v logoch veľké, pridať konf. premennú ai_auditMaxLength kde sa bude dať nastaviť max dlĺžka textu čo s zaaudituje, môžeš použiť DB.prepareString ktorý to vie orezať. Ak bude zadaná hodnota 0, tak sa to do auditu ani nezapíše. Default nastav na 200, to by malo stačiť.
Ja som už spravil auditovanie chyby v getAiImageResponse kde som použil fintu pomocou RequestBean.addAuditValue(SupportLogic.AUDIT_AI_RESPONSE_KEY, DB.prepareString(responseText, 5000).trim()) čo nastaví hodnotu do RequestBeanu z ktorého to potom vyberie najbližšie volanie Adminlog.add, to by si mohol použiť podobne, len do RequestBeanu nastaviť hodnoty a pri auditovaní počtu tokenov sa to tam samé nájde a zapíše.
2. Práva - je potrebné pridať právo Zobraziť AI tlačidlo, pridať do src/main/webapp/components/webjet9/modinfo3.properties s nastaveným leftSubmenu3DefaultDisabled=false aby tlačidlo bolo defaultne povolené. Kontrolu pridať do metód ktoré generujú AI column v JSON objekte (keď nemá právo, ani sa nevygeneruje), ale keďže máme špeci tlačidlo v elfinderi, tak to treba pridať aj do app-init.js do funkcie initAiOtherButtons. V JS kóde vieš použiť WJ.hasPermission na kontrolu práva. Tiež upraviť REST službu AssistantController, teraz sa tam kontroluje len isAdmin, kontrolovať toto právo.
3. Tvoja obľúbená štatistika - pod existujúcu tabuľku pridať ešte graf TOP 10 používateľov (povedzme bar graf) kde bude počet tokenov per používateľ a pod to tabuľku kde bude meno používateľa a počet minutých tokenov za zvolené obdobie. Aby vedeli sledovať koľko tokenov ktorý používateľ minul. Tiež upraviť autotesty, aby sa na rôzne možnosti prihlásil tester2, tester3 atď cez I.relogin (nezabudni na konci dať scenar na logoff aby keď to niekde padlo nezostal prihláseny tester3). Takto aj na serveri budeme mať nejaké rozumnejšie dáta, nielen všetko od jedného usera.

Doriešiť ešte nastavenie modulu v licenčnom serveri, povoliť len pre Pro a Enterprise, pridať do buildu, overiť, že v Basic sa nezobrazuje, presunúť modinfo do /components/ai/ aby to bolo v štandarde.