### PR TITLE
hotfix/58317-7-docmirroring-vs-multigroup-mapping

### DIFF
--- a/.agents/skills/wj-code-review/SKILL.md
+++ b/.agents/skills/wj-code-review/SKILL.md
@@ -26,16 +26,23 @@ Performs a read-only code review of changes in the repository — either all com
 
 Based on the answer, use one of the two modes:
 
+When running branch-level review commands in this skill, resolve the comparison base as follows:
+
+- Branches starting with `hotfix/` -> `origin/hotfix/2026.0-main`
+- All other branches -> `origin/main`
+
 #### Mode A — Pull Request (all commits in branch)
 
 ```bash
-git rev-parse --abbrev-ref HEAD
-git diff --name-only $(git merge-base HEAD origin/main)
+BASE_BRANCH=origin/main
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$CURRENT_BRANCH" == hotfix/* ]]; then BASE_BRANCH=origin/hotfix/2026.0-main; fi
+git diff --name-only $(git merge-base HEAD $BASE_BRANCH)
 ```
 
 For each file:
 ```bash
-git diff $(git merge-base HEAD origin/main) -- <file>
+git diff $(git merge-base HEAD $BASE_BRANCH) -- <file>
 ```
 
 #### Mode B — Uncommitted changes only (staged + unstaged)

--- a/.agents/skills/wj-code-review/SKILL.md
+++ b/.agents/skills/wj-code-review/SKILL.md
@@ -1,25 +1,44 @@
 ---
 name: wj-code-review
-description: 'Reviews uncommitted code changes for correctness, backward compatibility, and code quality. Use when: reviewing staged or unstaged changes before commit, checking backward compatibility of modifications, performing code review of local changes, analyzing new code patterns and suggesting improvements.'
-argument-hint: 'Optionally specify which files or area to focus the review on (e.g. "REST controllers" or "JPA entities").'
+description: 'Reviews code changes for correctness, backward compatibility, and code quality. Use when: reviewing staged or unstaged changes before commit, reviewing all changes in a pull request before merge, checking backward compatibility of modifications, performing code review of local changes, analyzing new code patterns and suggesting improvements.'
+argument-hint: 'Optionally specify which files or area to focus the review on (e.g. "REST controllers" or "JPA entities"). You can also specify the mode: "PR" to review all commits in the current branch, or "local" to review only uncommitted changes.'
 ---
 
 # wj-code-review
 
-Performs a read-only code review of uncommitted changes in the repository. Reports findings, risks, and improvement suggestions without modifying any files.
+Performs a read-only code review of changes in the repository — either all commits in the current branch (PR mode) or only uncommitted local changes. Reports findings, risks, and improvement suggestions without modifying any files.
 
 ## When to Use
 
 - Before committing changes to verify correctness and backward compatibility
+- Before merging a pull request to review all changes in the branch
 - When you want a second opinion on your code changes
 - To check for common anti-patterns, security issues, and potential regressions
 - To analyze new code for quality and adherence to project conventions
 
 ## Procedure
 
-### 1. Collect Uncommitted Changes
+### 1. Determine the Scope of Changes
 
-Run the following commands to identify all changed files:
+**Ask the user (if not already specified):**
+
+> "Do you want to review all commits in the current branch (PR mode), or only uncommitted local changes?"
+
+Based on the answer, use one of the two modes:
+
+#### Mode A — Pull Request (all commits in branch)
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git diff --name-only $(git merge-base HEAD origin/main)
+```
+
+For each file:
+```bash
+git diff $(git merge-base HEAD origin/main) -- <file>
+```
+
+#### Mode B — Uncommitted changes only (staged + unstaged)
 
 ```bash
 git diff --name-only
@@ -27,7 +46,13 @@ git diff --cached --name-only
 git status --short
 ```
 
-Categorize the files:
+For each file:
+```bash
+git diff <file>
+git diff --cached <file>
+```
+
+In both modes, categorize the files:
 
 - **Modified** (`M`) — existing files with changes
 - **Added** (`A`, `??`) — new files
@@ -36,12 +61,7 @@ Categorize the files:
 
 ### 2. Examine Each Change in Detail
 
-For each changed file, get the full diff:
-
-```bash
-git diff <file>
-git diff --cached <file>
-```
+Get the full diff for each changed file using the appropriate command from Step 1 (Mode A or Mode B).
 
 For new (untracked) files, read the entire file content.
 

--- a/.agents/skills/wj-codeceptjs/SKILL.md
+++ b/.agents/skills/wj-codeceptjs/SKILL.md
@@ -1,0 +1,599 @@
+---
+name: wj-codeceptjs
+description: Skill for writing E2E (end-to-end) tests using CodeceptJS with Playwright in WebJET CMS. Use when creating new automated browser tests, testing datatable CRUD operations, testing import functionality, verifying UI elements, testing permissions/rights, or writing test scenarios for admin pages.
+---
+
+# CodeceptJS E2E Testing Skill for WebJET CMS
+
+## Overview
+
+WebJET CMS uses **CodeceptJS** with **Playwright** for automated E2E browser testing. Tests are written in JavaScript and located in `src/test/webapp/tests/` directory, organized by modules/applications.
+
+## Project Structure
+
+```
+src/test/webapp/
+├── codecept.conf.js          # Main configuration (helpers, plugins, login, etc.)
+├── steps_file.js             # Custom I.* step definitions
+├── custom_helper.js          # Custom Playwright helper methods
+├── pages/
+│   ├── DataTables.js         # Automated datatable CRUD testing (baseTest, importTest)
+│   ├── DT.js                 # DataTable helper functions (filter, waitForLoader, etc.)
+│   ├── DTE.js                # DataTable Editor helper functions (save, cancel, fillField, etc.)
+│   ├── Document.js           # Document/page helper functions (switchDomain, screenshots, etc.)
+│   ├── Browser.js            # Browser detection (isChromium, isFirefox)
+│   ├── TempMail.js           # Temp email testing support
+│   ├── Apps.js               # Application-specific helpers
+│   ├── i18n.js               # Internationalization helpers
+│   └── buttons.js            # Button selector definitions
+├── screenshots/
+│   └── base/                 # Reference screenshots for visual testing
+└── tests/
+    ├── admin/                # Admin login/logout tests
+    ├── apps/                 # Application tests (banner, gallery, dmail, etc.)
+    ├── components/           # Component tests (templates, insert-script, etc.)
+    ├── settings/             # Settings tests (translation-keys, etc.)
+    ├── webpages/             # Web page tests
+    └── pentests/             # Penetration/security tests
+```
+
+## Critical Rules
+
+1. **Feature naming**: Always use the format `adresár.podadresár.meno-súboru` matching the test file path:
+   ```javascript
+   // File: tests/apps/banner/banner.js
+   Feature('apps.banner.banner');
+   ```
+
+2. **Testing data**: All created test objects **MUST** contain text `autotest` for identification. Use `I.getRandomText()` for unique suffixes:
+   ```javascript
+   var randomNumber = I.getRandomText();
+   auto_name = 'name-autotest-' + randomNumber;
+   ```
+
+3. **No fixed waits**: Never use `I.wait(N)` for synchronization. Always use `waitFor*` methods:
+   ```javascript
+   // BAD
+   I.click("Pridať");
+   I.wait(1);
+   I.see("test-text");
+
+   // GOOD
+   I.click("Pridať");
+   I.waitForText("test-text", 10, container);
+   ```
+
+4. **Every save must wait**: After clicking Save, always wait for loader:
+   ```javascript
+   DTE.save();        // internally waits for DTE loader + DT loader
+   // or manually:
+   I.click("Uložiť");
+   DTE.waitForLoader();
+   DT.waitForLoader();
+   ```
+
+5. **Comments in English**: Write all code comments in English.
+
+6. **Permissions testing is mandatory**: For datatable tests, always include `perms` parameter.
+
+## Authentication
+
+Use the pre-configured `login` injection in `Before` blocks:
+
+```javascript
+Feature('apps.my-feature');
+
+Before(({ login }) => {
+    login('admin');
+});
+
+Scenario('my test', ({ I }) => {
+    I.amOnPage("/admin/v9/apps/my-app/");
+    // ... test code
+});
+```
+
+The `login('admin')` function handles logging in as `tester` user, manages cookies, and sets default window size. It is defined in `codecept.conf.js` autoLogin plugin.
+
+## Running Tests
+
+```shell
+cd src/test/webapp/
+
+# Run all tests
+npm run all
+
+# Run specific test with pause on fail
+npm run pause tests/apps/banner/banner.js
+
+# Run scenarios tagged @current
+npm run current
+
+# Run on different URL, headless
+CODECEPT_URL="http://demotest.webjetcms.sk" CODECEPT_SHOW=false npm run all
+```
+
+## Available Helper Functions
+
+### I.* (Standard Playwright + Custom WebJET)
+
+**Core Playwright methods:**
+- `I.amOnPage(url)` - navigate to page
+- `I.click(locator, context?)` - click element
+- `I.forceClick(locator)` - force click (use for custom checkboxes)
+- `I.fillField(locator, value)` - fill input field
+- `I.see(text, context?)` / `I.dontSee(text, context?)` - assert text visibility
+- `I.seeElement(locator)` / `I.dontSeeElement(locator)` - assert element visibility
+- `I.selectOption(locator, value)` - select dropdown option
+- `I.waitForText(text, timeout, context?)` - wait for text to appear
+- `I.waitForElement(locator, timeout)` - wait for element
+- `I.waitForVisible(locator, timeout)` - wait for element to be visible
+- `I.waitToHide(locator, timeout)` - wait for element to hide
+- `I.pressKey(key)` - press keyboard key
+- `I.executeScript(fn)` - execute JavaScript in browser
+- `I.saveScreenshot(filename)` - save screenshot
+- `I.seeInField(locator, value)` - check field value
+- `I.grabTextFrom(locator)` - get text content (async)
+- `I.grabNumberOfVisibleElements(locator)` - count visible elements (async)
+- `I.grabCssPropertyFrom(locator, prop)` - get CSS property (async)
+
+**Custom WebJET methods:**
+- `I.getRandomText()` - returns unique random text suffix for test data
+- `I.getRandomTextShort()` - returns shorter random text
+- `I.formatDateTime(timestamp)` - format timestamp to date string
+- `I.seeAndClick(selector)` - wait for element then click
+- `await I.clickIfVisible(selector)` - click if visible, skip if not (no error)
+- `I.verifyDisabled(selector)` - verify field is disabled
+- `I.wjSetDefaultWindowSize()` - reset window to default size
+- `I.waitForTime(time)` - wait until specific timestamp
+- `I.toastrClose()` - close toastr notification
+- `I.clickCss(selector, parent?)` - click using CSS selector (faster than `I.click({css: ...})`)
+- `I.forceClickCss(selector, parent?)` - force click using CSS selector
+- `I.jstreeClick(name)` - click node in jstree (important for web pages where link name matches directory)
+- `I.jstreeNavigate(pathArray)` - navigate jstree by path array, e.g. `I.jstreeNavigate(["Aplikácie", "Bannerový systém"])`
+- `I.createFolderStructure(randomNumber)` - create test folder structure
+- `I.deleteFolderStructure(randomNumber)` - delete test folder structure
+- `I.logout()` - logout current user
+- `I.closeOtherTabs()` - close all tabs except current
+- `I.openNewTab()` - open new browser tab
+- `I.closeCurrentTab()` - close current tab
+- `I.getDefaultPassword()` - get test user password
+- `I.getDefaultDomainName()` - get default domain name
+- `await I.getDataTableColumns(dataTableName)` - get datatable columns definition
+- `await I.getDataTableId(dataTableName)` - get datatable DOM ID
+- `await I.getTotalRows()` - get total rows in datatable
+- `I.dtWaitForLoader()` - shortcut for DT.waitForLoader()
+- `I.dtFilterSelect(name, value)` - shortcut for DT.filterSelect()
+- `I.dtResetTable(name)` - reset datatable to default state
+
+### DT.* (DataTable functions)
+
+Implemented in `src/test/webapp/pages/DT.js`:
+
+- `DT.waitForLoader(name?)` - wait for datatable processing indicator to disappear. Usage: `DT.waitForLoader()` or `DT.waitForLoader("bannerDataTable")`
+- `DT.filter(name, value, type?)` - set text filter on column. Type options: `'contains'`, `'startwith'`, `'endwith'`, `'equal'`
+- `DT.filterContains(name, value)` - shortcut for filter with contains type
+- `DT.filterSelect(name, value)` - set select filter value, e.g. `DT.filterSelect('cookieClass', 'Neklasifikované')`
+- `DT.deleteAll(name?)` - delete all currently visible records (always filter first!)
+- `DT.checkPerms(perms, url, datatableId?)` - test permission enforcement on datatable
+- `DT.checkTableCell(tableId, row, col, value)` - verify cell value (1-indexed)
+- `DT.checkTableRow(tableId, row, values)` - verify entire row values
+- `DT.addContext(key, selector)` - add new context for button selectors
+- `await DT.showColumn(name, dataTable)` - show a hidden column
+
+### DTE.* (DataTable Editor functions)
+
+Implemented in `src/test/webapp/pages/DTE.js`:
+
+- `DTE.waitForLoader()` - wait for editor save operation to finish
+- `DTE.waitForEditor(name?)` - wait for editor dialog to appear. Default datatable: `datatableInit`
+- `DTE.waitForModalClose(modalId)` - wait for editor modal to close
+- `DTE.save(name?)` - click Save button and wait for save+reload
+- `DTE.saveBubble()` - save via bubble editor
+- `DTE.cancel(name?, clickTopButton?)` - click Cancel/Close button
+- `DTE.selectOption(name, text)` - select value in dropdown, e.g. `DTE.selectOption("bannerType", "HTML kód")`
+- `await DTE.selectOptionMulti(name, values)` - select multiple dropdown values (async)
+- `DTE.fillField(name, value)` - fill field by backend field name (uses `#DTE_Field_name` selector)
+- `DTE.appendField(name, value)` - append text to field (workaround for I.appendField issues)
+- `DTE.fillQuill(name, value)` - fill Quill editor field
+- `DTE.fillCkeditor(htmlCode)` - set HTML in CKEditor
+- `DTE.fillCleditor(parentSelector, value)` - fill cleditor WYSIWYG
+
+### Document.* (Document/Page functions)
+
+- `Document.switchDomain(domain)` - switch domain, e.g. `Document.switchDomain("test23.tau27.iway.sk")`
+- `Document.setConfigValue(name, value)` - set configuration variable
+- `Document.resetPageBuilderMode()` - reset editor mode
+- `Document.notifyClose()` - close toastr notification
+- `Document.notifyCheckAndClose(text)` - verify and close toastr notification
+- `Document.editorComponentOpen()` - open component settings in page editor
+- `Document.editorComponentOk()` - click OK in component settings
+- `Document.scrollTo(selector)` - scroll to element
+- `await Document.compareScreenshotElement(selector, filename, width?, height?, tolerance?)` - visual comparison test
+
+### Browser.* (Browser detection)
+
+- `Browser.isChromium()` - returns true if running in Chromium
+- `Browser.isFirefox()` - returns true if running in Firefox
+
+### Assert functions (codeceptjs-chai)
+
+```javascript
+I.assertEqual(actual, expected, message?);
+I.assertNotEqual(actual, expected, message?);
+I.assertContain(target, value, message?);
+I.assertNotContain(target, value, message?);
+I.assertStartsWith(target, value, message?);
+I.assertEndsWith(target, value, message?);
+I.assertTrue(value, message?);
+I.assertFalse(value, message?);
+I.assertAbove(actual, expected, message?);
+I.assertLengthOf(target, length, message?);
+I.assertEmpty(target, message?);
+```
+
+## Locators
+
+CodeceptJS supports multiple locator types:
+
+```javascript
+// By text (default for most methods)
+I.click("Submit");
+I.see("Welcome");
+
+// By CSS
+I.click({css: "button.btn-primary"});
+
+// By XPath
+I.click({xpath: "//button[@type='submit']"});
+
+// By name attribute
+I.fillField({name: "username"}, "tester");
+
+// By ID (permalink)
+I.click({permalink: '/foo'});  // matches id="foo"
+
+// By class
+I.click({class: 'foo'});
+
+// Using locate() builder
+I.click(locate("a").withText("Click me"));
+I.click(locate(".item").withChild("span.icon"));
+I.click(locate("tr").withDescendant("td").withText("Banner"));
+
+// Within context
+within("div.modal-dialog", () => {
+    I.fillField("name", "test");
+    I.click("Save");
+});
+
+// Or with context parameter
+I.click("Save", "div.modal-dialog");
+```
+
+## Writing a DataTable CRUD Test (baseTest)
+
+The `DataTables.baseTest()` function provides automated CRUD testing. It:
+1. Creates a new record (tests required field validation)
+2. Searches for the created record
+3. Edits the record
+4. Tests cross-domain record separation
+5. Searches for the edited record
+6. Deletes the record
+7. Verifies audit log entries
+
+### Minimal Example
+
+```javascript
+Feature('apps.my-app');
+
+Before(({ login }) => {
+    login('admin');
+});
+
+Scenario('zakladne testy @baseTest', async ({ I, DataTables }) => {
+    I.amOnPage("/admin/v9/apps/my-app/");
+
+    await DataTables.baseTest({
+        dataTable: 'myAppTable',     // JavaScript variable name in the web page
+        perms: 'cmp_my_app'          // permission name to test (MANDATORY)
+    });
+});
+```
+
+**IMPORTANT**: The `dataTable` value must match the **JavaScript variable name** defined in the page's pug file with `var` (not `let`):
+```javascript
+var myAppTable;
+window.domReady.add(function() {
+    myAppTable = WJ.DataTable({ ... });
+});
+```
+
+### Full Example with Custom Steps
+
+```javascript
+Scenario('zakladne testy @baseTest', async ({ I, DataTables, DT, DTE }) => {
+    I.amOnPage("/admin/v9/apps/my-app/");
+
+    await DataTables.baseTest({
+        dataTable: 'myAppTable',
+        perms: 'cmp_my_app',
+
+        // Override required fields (otherwise auto-detected from columns with required: true)
+        requiredFields: ['name', 'email'],
+
+        // Custom values for fields with specific format (e.g. email)
+        testingData: {
+            email: "test@autotest-example.com"
+        },
+
+        // Steps executed when creating new record
+        createSteps: function(I, options, DT, DTE) {
+            I.click({css: "#pills-dt-myAppTable-advanced-tab"});
+            I.fillField("div.DTE_Field_Name_description input", "Test description");
+            I.click({css: "#pills-dt-myAppTable-main-tab"});
+        },
+
+        // Steps executed after record is saved
+        afterCreateSteps: function(I, options, requiredFields, DT, DTE) {
+            // Can modify requiredFields or testingData for subsequent steps
+        },
+
+        // Steps executed when editing existing record
+        editSteps: function(I, options, DT, DTE) {
+            I.fillField("div.DTE_Field_Name_description input", "Edited description");
+        },
+
+        // Steps for searching edited record
+        editSearchSteps: function(I, options, DT, DTE) {
+            I.see(`${options.testingData[0]}-chan.ge`, "div.dt-scroll-body");
+        },
+
+        // Steps before deleting record
+        beforeDeleteSteps: function(I, options, DT, DTE) {
+            // Verify something before deletion
+        },
+
+        // Optional settings
+        skipRefresh: false,              // don't refresh page after create
+        skipSwitchDomain: false,         // skip cross-domain test
+        switchDomainName: "mirroring.tau27.iway.sk",  // custom domain for cross-domain test
+        skipDuplication: false,          // skip duplication test
+        container: null,                 // CSS selector for nested datatable container
+        containerModal: null,            // CSS selector for editor modal container
+        extraWait: null                  // extra wait time in seconds
+    });
+});
+```
+
+### baseTest Options Reference
+
+**Required:**
+- `dataTable` - JavaScript variable name of the datatable in the web page
+
+**Mandatory (for security testing):**
+- `perms` - permission name for REST service access testing (use `'-'` to skip for nested tables)
+
+**Optional:**
+- `requiredFields` - array of required field names (auto-detected if not specified)
+- `testingData` - object with custom values for specific fields
+- `container` - CSS selector for datatable container (for nested datatables)
+- `containerModal` - CSS selector for editor modal (for nested datatables)
+- `skipRefresh` - `true` to skip page refresh after create
+- `skipSwitchDomain` - `true` to skip cross-domain separation test
+- `switchDomainName` - custom domain name for cross-domain test
+- `skipDuplication` - `true` to skip duplication test
+- `createSteps` - `function(I, options, DT, DTE)` - custom create steps
+- `afterCreateSteps` - `function(I, options, requiredFields, DT, DTE)` - post-create steps
+- `editSteps` - `function(I, options, DT, DTE)` - custom edit steps
+- `editSearchSteps` - `function(I, options, DT, DTE)` - custom search-after-edit steps
+- `beforeDeleteSteps` - `function(I, options, DT, DTE)` - pre-delete steps
+- `extraWait` - extra wait time in seconds
+
+**Automatically set after initialization:**
+- `options.id` - datatable DOM ID
+- `options.url` - current page URL
+- `options.testingData` - array of filled required field values
+- `options.columns` - columns definition from datatable
+
+### How Required Fields Are Generated
+
+Test values are auto-generated with `autotest` text:
+- Regular fields: `{fieldName}-autotest-{randomText}`
+- Email fields: `{fieldName}-autotest-{randomTextShort}@onetimeusemail.com`
+- Custom values from `testingData` override auto-generation
+
+## Writing a DataTable Import Test (importTest)
+
+The `DataTables.importTest()` function tests Excel import functionality:
+1. Verifies table has no existing test data
+2. Imports Excel file and verifies data
+3. Edits required fields (adds `-changed` suffix) and verifies
+4. Re-imports with matching to verify data update
+
+### Example
+
+```javascript
+Scenario('import test', async ({ I, DataTables }) => {
+    I.waitForText('Zoznam skriptov', 5);
+    await DataTables.importTest({
+        dataTable: 'insertScriptTable',
+        requiredFields: ['name', 'position'],
+        file: 'tests/components/insert-script.xlsx',
+        updateBy: 'Názov / popis skriptu - name',
+        rows: [
+            {
+                name: "Test import"
+            }
+        ]
+    });
+});
+```
+
+### Import Test Options
+
+- `file` - path to .xlsx file with test data (relative to `src/test/webapp/`)
+- `updateBy` - column name/label for "Update existing records" matching
+- `rows` - array of objects with column names and values for filtering/verification
+- `preserveColumns` - array of column names not in Excel to verify they survive import unchanged
+
+### Preparing Import Test Data
+
+1. Create a test record in the table with many fields filled
+2. Export table to Excel
+3. Keep only header row and test record
+4. Keep original ID (to verify it won't be overwritten)
+5. Add `-import-test` suffix to values for identification
+6. Save .xlsx file next to the test .js file with matching name
+
+## Testing Permissions/Rights
+
+### In baseTest (automatic)
+
+```javascript
+await DataTables.baseTest({
+    dataTable: 'mediaGroupsTable',
+    perms: 'editor_edit_media_group'
+});
+```
+
+### Manual permission testing
+
+```javascript
+Scenario('test permissions', ({ I, DT }) => {
+    I.amOnPage("/admin/v9/apps/my-app/");
+    DT.waitForLoader();
+    I.see("Expected Data");
+
+    // Test with removed permission
+    DT.checkPerms("myPermName", "/admin/v9/apps/my-app/");
+});
+```
+
+### Testing button-level permissions with forceShowButton
+
+```javascript
+Scenario('button permissions', ({ I, DT, DTE }) => {
+    // Verify buttons are hidden when permissions removed
+    I.amOnPage("/admin/v9/apps/my-app/?removePerm=addRecord,editRecord,deleteRecord");
+    I.dontSeeElement("#datatableInit_wrapper button.buttons-create");
+    I.dontSeeElement("#datatableInit_wrapper button.buttons-edit");
+    I.dontSeeElement("#datatableInit_wrapper button.buttons-remove");
+
+    // Verify REST service rejects operations even with forced buttons
+    I.amOnPage("/admin/v9/apps/my-app/?removePerm=addRecord,editRecord,deleteRecord,forceShowButton");
+    DT.waitForLoader();
+    I.clickCss("#datatableInit_wrapper button.buttons-create");
+    DTE.waitForEditor();
+    I.fillField("name", "test");
+    DTE.save();
+    I.see("nemáte právo");  // Verify error message
+    DTE.cancel();
+});
+```
+
+## Visual Testing (Screenshots)
+
+```javascript
+await Document.compareScreenshotElement(
+    "#insertScriptTable_wrapper",           // CSS selector of element
+    "autotest-insert-script-settings.png",  // screenshot filename (prefix with autotest-)
+    1280,                                   // optional: window width
+    270,                                    // optional: window height
+    5                                       // optional: tolerance (0-100)
+);
+```
+
+Reference images go to `src/test/webapp/screenshots/base/`. On first run, actual screenshot is saved to `build/test/screenshots/actual/`.
+
+## Complete Test File Template
+
+```javascript
+Feature('apps.my-module.my-feature');
+
+var auto_name;
+
+Before(({ I, login }) => {
+    login('admin');
+    I.amOnPage('/admin/v9/apps/my-feature/');
+
+    if (typeof auto_name == "undefined") {
+        var randomNumber = I.getRandomText();
+        auto_name = 'name-autotest-' + randomNumber;
+    }
+});
+
+Scenario('zakladne testy @baseTest', async ({ I, DataTables, DT, DTE }) => {
+    await DataTables.baseTest({
+        dataTable: 'myFeatureTable',
+        perms: 'cmp_my_feature',
+        createSteps: function(I, options, DT, DTE) {
+            // Fill additional fields during create
+        },
+        editSteps: function(I, options, DT, DTE) {
+            // Modify fields during edit
+        }
+    });
+});
+
+Scenario('specific feature test', ({ I, DT, DTE }) => {
+    // Navigate and verify specific behavior
+    I.waitForText("Expected text", 10);
+    DT.filter("name", "search-value");
+    I.click("Record name");
+    DTE.waitForEditor();
+    // Verify editor content
+    I.seeInField("Field name", "expected value");
+    DTE.cancel();
+});
+
+Scenario('domain switching', ({ I, Document }) => {
+    I.see("Record from main domain");
+    Document.switchDomain("test23.tau27.iway.sk");
+    I.dontSee("Record from main domain");
+});
+
+Scenario('odhlasenie', ({ I }) => {
+    // Logout if you changed domain or user state
+    I.logout();
+});
+```
+
+## REST API Testing
+
+```javascript
+Feature('api.my-service');
+
+Before(({ I }) => {
+    I.amOnPage('/logoff.do?forward=/admin/');
+});
+
+Scenario("API call", ({ I }) => {
+    I.sendGetRequest('/admin/rest/web-pages/all?groupId=25');
+    I.seeResponseCodeIs(200);
+    I.seeResponseContainsKeys(['numberOfElements', 'totalPages']);
+    I.seeResponseContainsJson({
+        content: [{ "id": 11, "groupId": 25, "title": "Produktová stránka" }]
+    });
+});
+
+Scenario("API unauthorized", ({ I }) => {
+    I.sendGetRequest('/admin/rest/web-pages/all?groupId=25', {
+        'x-auth-token': 'invalid-token'
+    });
+    I.seeResponseCodeIs(401);
+});
+```
+
+## Best Practices Summary
+
+1. **Feature naming**: Match file path - `Feature('apps.banner.banner')` for `tests/apps/banner/banner.js`
+2. **Test data isolation**: Use `autotest` prefix + `I.getRandomText()` for all test data
+3. **Create & cleanup in separate scenarios**: If creation scenario fails, cleanup scenarios still run
+4. **Use proper selectors**: Narrow CSS selectors with parent context (e.g. `"#bannerDataTable td.dt-row-edit"`)
+5. **Verify selectors in browser console**: Use `$("your-selector")` in F12 console to verify uniqueness
+6. **No fixed waits**: Use `waitForText`, `waitForElement`, `waitForVisible`, `DT.waitForLoader()`, `DTE.waitForEditor()`, `DTE.waitForLoader()`
+7. **Short focused scenarios**: Don't mix unrelated tests in one scenario
+8. **Always test permissions**: Use `perms` parameter in baseTest or manual `DT.checkPerms()`
+9. **Logout after domain change**: If test switches domain, add `Scenario('odhlasenie', ({I}) => { I.logout(); })`
+10. **No After() function**: Don't use `After()` - it interferes with pauseOnFail debugging

--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -28,6 +28,7 @@
 - Webové stránky - zladené získanie zoznamu šablón medzi web stránkami a priečinkami (#58317-03).
 - Webové stránky - opravený prenos dátumov publikovania pri náhľade web stránky a presmerovanie pri vlastnostiach bloku (#osk412).
 - Webové stránky - opravená chyba získania [šablóny pre mobilné zariadenia](frontend/templates/templates.md#zobrazenie-pre-špecifické-zariadenie) v MultiWEB inštalácii pri zhode mien šablóny v rôznych doménach (#58317-5).
+- Webové stránky - opravené ukladanie stránky, ktorá má kópie vo viacerých priečinkoch a zároveň je použité zrkadlenie stránok (#58317-7).
 
 ## 2026.0
 

--- a/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
+++ b/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
@@ -4,7 +4,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -410,7 +409,9 @@ public class DocMirroringServiceV9 {
       return languages;
    }
 
-   public static void handleMultigroupMapping(DocDetails editedDoc, List<GroupDetails> otherGroups, Map<Integer, Integer> groupMapping, List<Integer> toDelete, boolean redirect, HttpServletRequest request) {
+   public static void handleMultigroupMapping(DocDetails editedDoc, List<Integer> toDelete, boolean redirect, HttpServletRequest request) {
+      if (editedDoc.getSyncId()<1) return;
+
       List<DocDetails> syncedMasterDocs = getDocBySyncId(editedDoc.getSyncId(), editedDoc.getDocId());
       List<Integer> slaveDocIds = MultigroupMappingDB.getSlaveDocIds(editedDoc.getDocId());
 

--- a/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
+++ b/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
@@ -4,6 +4,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
 
 import sk.iway.iwcm.Constants;
 import sk.iway.iwcm.LabelValueDetails;
@@ -19,6 +22,7 @@ import sk.iway.iwcm.doc.DocDB;
 import sk.iway.iwcm.doc.DocDetails;
 import sk.iway.iwcm.doc.GroupDetails;
 import sk.iway.iwcm.doc.GroupsDB;
+import sk.iway.iwcm.doc.MultigroupMappingDB;
 import sk.iway.iwcm.editor.service.EditorService;
 import sk.iway.iwcm.editor.service.GroupsService;
 import sk.iway.iwcm.i18n.Prop;
@@ -404,5 +408,43 @@ public class DocMirroringServiceV9 {
       }
 
       return languages;
+   }
+
+   public static void handleMultigroupMapping(DocDetails editedDoc, List<GroupDetails> otherGroups, Map<Integer, Integer> groupMapping, List<Integer> toDelete, boolean redirect, HttpServletRequest request) {
+      List<DocDetails> syncedMasterDocs = getDocBySyncId(editedDoc.getSyncId(), editedDoc.getDocId());
+      List<Integer> slaveDocIds = MultigroupMappingDB.getSlaveDocIds(editedDoc.getDocId());
+
+      GroupsDB groupsDB = GroupsDB.getInstance();
+
+      for (DocDetails syncedDoc : syncedMasterDocs) {
+         //delete mapping for this syncedDoc
+         MultigroupMappingDB.deleteSlaves(syncedDoc.getDocId());
+
+         GroupDetails syncedDocGroup = groupsDB.getGroup(syncedDoc.getGroupId());
+         String syncedLng = GroupMirroringServiceV9.getLanguage(syncedDocGroup);
+
+         //potrebujem najst v EN verzii stranky ktore su v SK verzii nastavene ako multigroup - teda sú v slaveDocIds
+         for (Integer slaveDocId : slaveDocIds) {
+            List<DocDetails> syncedSlaveDocs = getDocBySyncId(getSyncId(slaveDocId), slaveDocId);
+            for (DocDetails syncedSlaveDoc : syncedSlaveDocs) {
+               GroupDetails syncedSlaveDocGroup = groupsDB.getGroup(syncedSlaveDoc.getGroupId());
+               String syncedSlaveLng = GroupMirroringServiceV9.getLanguage(syncedSlaveDocGroup);
+
+               if (syncedSlaveLng.equals(syncedLng)) {
+                  //nasiel som stranku, ktora je v rovnakej jazykovej verzii ako aktualne spracovavana stranka, takze to je ten spravny slave
+                  Logger.debug(DocMirroringServiceV9.class, "NASTAVUJEM MAPPING, syncedDoc="+syncedDoc.getDocId()+" slaveDocId="+syncedSlaveDoc.getDocId());
+                  MultigroupMappingDB.newMultigroupMapping(syncedSlaveDoc.getDocId(), syncedDoc.getDocId(), redirect);
+               }
+            }
+         }
+      }
+
+      for(Integer docId : toDelete) {
+         int syncId = getSyncId(docId);
+         List<DocDetails> syncedDocs = getDocBySyncId(syncId, docId);
+         for (DocDetails syncedDoc : syncedDocs) {
+            DocDB.deleteDoc(syncedDoc.getDocId(), request, false);
+         }
+      }
    }
 }

--- a/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
+++ b/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
@@ -301,6 +301,9 @@ public class DocMirroringServiceV9 {
     */
    public static List<DocDetails> getDocBySyncId(int syncId, int skipDocId)
 	{
+      List<DocDetails> filtered = new ArrayList<>();
+      if (syncId<1) return filtered;
+
       StringBuilder sql = new StringBuilder();
       sql.append("SELECT ").append(DocDB.getDocumentFields()).append(" FROM documents d WHERE d.sync_id=?");
       if (skipDocId>0) sql.append(" AND d.doc_id!=? ");
@@ -328,7 +331,6 @@ public class DocMirroringServiceV9 {
       GroupsDB groupsDB = GroupsDB.getInstance();
 
       //filter groups which is not synced anymore
-      List<DocDetails> filtered = new ArrayList<>();
       for (DocDetails doc : docs) {
          List<GroupDetails> parents = groupsDB.getParentGroups(doc.getGroupId(), true);
          for (GroupDetails parent : parents) {
@@ -433,7 +435,9 @@ public class DocMirroringServiceV9 {
 
          //potrebujem najst v EN verzii stranky ktore su v SK verzii nastavene ako multigroup - teda sú v slaveDocIds
          for (Integer slaveDocId : slaveDocIds) {
-            List<DocDetails> syncedSlaveDocs = getDocBySyncId(getSyncId(slaveDocId), slaveDocId);
+            int syncId = getSyncId(slaveDocId);
+            if (syncId < 1) continue;
+            List<DocDetails> syncedSlaveDocs = getDocBySyncId(syncId, slaveDocId);
             for (DocDetails syncedSlaveDoc : syncedSlaveDocs) {
                GroupDetails syncedSlaveDocGroup = groupsDB.getGroup(syncedSlaveDoc.getGroupId());
                String syncedSlaveLng = GroupMirroringServiceV9.getLanguage(syncedSlaveDocGroup);
@@ -449,6 +453,7 @@ public class DocMirroringServiceV9 {
 
       for(Integer docId : toDelete) {
          int syncId = getSyncId(docId);
+         if (syncId < 1) continue;
          List<DocDetails> syncedDocs = getDocBySyncId(syncId, docId);
          for (DocDetails syncedDoc : syncedDocs) {
             DocDB.deleteDoc(syncedDoc.getDocId(), request, false);

--- a/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
+++ b/src/main/java/sk/iway/iwcm/components/structuremirroring/DocMirroringServiceV9.java
@@ -409,6 +409,13 @@ public class DocMirroringServiceV9 {
       return languages;
    }
 
+   /**
+    * Handle multigroup mapping for edited doc, delete old mappings and create new based on current syncId and mapping configuration
+    * @param editedDoc - original saved doc - should always be automatically master
+    * @param toDelete - list of docIds to delete
+    * @param redirect - if true, the mapping will be created with redirect, if false without redirect
+    * @param request - HttpServletRequest object
+    */
    public static void handleMultigroupMapping(DocDetails editedDoc, List<Integer> toDelete, boolean redirect, HttpServletRequest request) {
       if (editedDoc.getSyncId()<1) return;
 

--- a/src/main/java/sk/iway/iwcm/editor/service/MultigroupService.java
+++ b/src/main/java/sk/iway/iwcm/editor/service/MultigroupService.java
@@ -13,6 +13,7 @@ import org.springframework.web.context.annotation.RequestScope;
 
 import sk.iway.iwcm.Constants;
 import sk.iway.iwcm.Logger;
+import sk.iway.iwcm.components.structuremirroring.DocMirroringServiceV9;
 import sk.iway.iwcm.doc.DocDB;
 import sk.iway.iwcm.doc.DocDetails;
 import sk.iway.iwcm.doc.GroupDetails;
@@ -94,11 +95,16 @@ public class MultigroupService {
 			Integer docId = me.getValue();
 			if(docId != null) {
 				Logger.debug(MultigroupService.class, "Saving slave doc: "+docId+" to group "+groupId);
+				int syncId = -1;
 				if(docId < 0) {
 					masterDoc.setVirtualPath("");
 				} else {
 					masterDoc.setVirtualPath(docDB.getBasicDocDetails(docId, true).getVirtualPath());
+					//get current syncId
+					syncId = DocMirroringServiceV9.getSyncId(docId);
 				}
+				//restore syncId for existing slave doc
+				masterDoc.setSyncId(syncId);
 
 				if (docIdOriginal == docId.intValue()) {
 					//keep virtual path for edited doc (slave)
@@ -138,8 +144,13 @@ public class MultigroupService {
 			}
 		}
 
+		//must be before DocDB.deleteDoc because it will remove also the mapping
+		DocMirroringServiceV9.handleMultigroupMapping(editedDoc, otherGroups, groupMapping, toDelete, redirect, request);
+
 		// odstranime DocDetails pre zmazane slave mappingy
-		for(Integer docId : toDelete) { DocDB.deleteDoc(docId, request); }
+		for(Integer docId : toDelete) {
+			DocDB.deleteDoc(docId, request, false);
+		}
 
 		//ak sme nieco zmazali refreshneme DocDB
 		if(toDelete.isEmpty()==false)	{

--- a/src/main/java/sk/iway/iwcm/editor/service/MultigroupService.java
+++ b/src/main/java/sk/iway/iwcm/editor/service/MultigroupService.java
@@ -144,7 +144,7 @@ public class MultigroupService {
 			}
 		}
 
-		//must be before DocDB.deleteDoc because it will remove also the mapping
+		//must be before DocDB.deleteDoc because DocDB.deleteDoc() will remove also the mapping
 		DocMirroringServiceV9.handleMultigroupMapping(editedDoc, toDelete, redirect, request);
 
 		// odstranime DocDetails pre zmazane slave mappingy

--- a/src/main/java/sk/iway/iwcm/editor/service/MultigroupService.java
+++ b/src/main/java/sk/iway/iwcm/editor/service/MultigroupService.java
@@ -145,7 +145,7 @@ public class MultigroupService {
 		}
 
 		//must be before DocDB.deleteDoc because it will remove also the mapping
-		DocMirroringServiceV9.handleMultigroupMapping(editedDoc, otherGroups, groupMapping, toDelete, redirect, request);
+		DocMirroringServiceV9.handleMultigroupMapping(editedDoc, toDelete, redirect, request);
 
 		// odstranime DocDetails pre zmazane slave mappingy
 		for(Integer docId : toDelete) {

--- a/src/main/java/sk/iway/iwcm/editor/service/MultigroupService.java
+++ b/src/main/java/sk/iway/iwcm/editor/service/MultigroupService.java
@@ -95,15 +95,15 @@ public class MultigroupService {
 			Integer docId = me.getValue();
 			if(docId != null) {
 				Logger.debug(MultigroupService.class, "Saving slave doc: "+docId+" to group "+groupId);
+				//every group of master-slave mapping has its own syncId, so we need to get it for each slave doc
 				int syncId = -1;
 				if(docId < 0) {
 					masterDoc.setVirtualPath("");
 				} else {
 					masterDoc.setVirtualPath(docDB.getBasicDocDetails(docId, true).getVirtualPath());
-					//get current syncId
+					//restore syncId for existing slave doc
 					syncId = DocMirroringServiceV9.getSyncId(docId);
 				}
-				//restore syncId for existing slave doc
 				masterDoc.setSyncId(syncId);
 
 				if (docIdOriginal == docId.intValue()) {

--- a/src/test/webapp/tests/webpages/pages-mirroring-wj9.js
+++ b/src/test/webapp/tests/webpages/pages-mirroring-wj9.js
@@ -306,6 +306,7 @@ Scenario('presun stranky webpage1 do podpriecinka sk-mir-subfolder1', ({ I, DT, 
 Scenario("multigroup mapping", ({ I, DT, DTE }) => {
      var auto_folder_sk = 'sk-mir-autotest-' + randomNumber;
      var auto_folder_en = 'en-mir-autotest-' + randomNumber;
+     var auto_subfolder2_sk = 'sk-mir-subfolder2-' + randomNumber;
      var auto_webpage1_sk = 'sk-multigroup-autotest-' + randomNumber;
 
      I.jstreeClick(auto_folder_sk);
@@ -331,8 +332,30 @@ Scenario("multigroup mapping", ({ I, DT, DTE }) => {
      I.seeElement(locate('tr.is-not-public').withText(auto_webpage1_sk));
      I.click(auto_webpage1_sk);
      DTE.waitForEditor();
+     I.clickCss('#pills-dt-datatableInit-basic-tab');
      I.seeInField("#editorAppDTE_Field_editorFields-groupCopyDetails input.form-control", '/' + auto_folder_en + '/' + auto_subfolder1_sk);
-     DTE.cancel();
+
+     //
+     I.say("Add auto_subfolder2_sk to multigroup mapping");
+     I.clickCss("#editorAppDTE_Field_editorFields-groupCopyDetails > section > div > div > button.btn-vue-jstree-add");
+     I.click(locate('#jsTree .jstree-node.jstree-closed').withText(auto_folder_en).find('.jstree-icon.jstree-ocl'));
+     I.click(locate('#jsTree').find('.jstree-node.jstree-leaf').withText(auto_subfolder2_sk).find('a.jstree-anchor'));
+     pause();
+
+     DTE.save();
+
+     //
+     I.say("Check if auto_subfolder2_sk is now also in SK version");
+     I.jstreeClick(auto_folder_sk);
+     I.wait(1);
+     DT.waitForLoader();
+     I.seeElement(locate('tr').withText(auto_webpage1_sk));
+     I.click(auto_webpage1_sk);
+     DTE.waitForEditor();
+     I.clickCss('#pills-dt-datatableInit-basic-tab');
+     I.seeInField("#editorAppDTE_Field_editorFields-groupCopyDetails div.form-group:nth-child(1) input.form-control", '/' + auto_folder_sk + '/' + auto_subfolder1_sk);
+     I.seeInField("#editorAppDTE_Field_editorFields-groupCopyDetails div.form-group:nth-child(2) input.form-control", '/' + auto_folder_sk + '/' + auto_subfolder2_sk);
+
 });
 
 Scenario('vymazanie hlavneho sk priecinka z test priecinka', ({ I, DT, DTE }) => {

--- a/src/test/webapp/tests/webpages/pages-mirroring-wj9.js
+++ b/src/test/webapp/tests/webpages/pages-mirroring-wj9.js
@@ -306,7 +306,6 @@ Scenario('presun stranky webpage1 do podpriecinka sk-mir-subfolder1', ({ I, DT, 
 Scenario("multigroup mapping", ({ I, DT, DTE }) => {
      var auto_folder_sk = 'sk-mir-autotest-' + randomNumber;
      var auto_folder_en = 'en-mir-autotest-' + randomNumber;
-     var auto_subfolder2_sk = 'sk-mir-subfolder2-' + randomNumber;
      var auto_webpage1_sk = 'sk-multigroup-autotest-' + randomNumber;
 
      I.jstreeClick(auto_folder_sk);

--- a/src/test/webapp/tests/webpages/pages-mirroring-wj9.js
+++ b/src/test/webapp/tests/webpages/pages-mirroring-wj9.js
@@ -303,7 +303,7 @@ Scenario('presun stranky webpage1 do podpriecinka sk-mir-subfolder1', ({ I, DT, 
      wj9MoveSubpage(I, DT, DTE, randomNumber);
 });
 
-Scenario("multigroup mapping", ({ I, DT, DTE }) => {
+Scenario("mirroring with multigroup mapping", ({ I, DT, DTE }) => {
      var auto_folder_sk = 'sk-mir-autotest-' + randomNumber;
      var auto_folder_en = 'en-mir-autotest-' + randomNumber;
      var auto_subfolder2_sk = 'sk-mir-subfolder2-' + randomNumber;
@@ -340,8 +340,6 @@ Scenario("multigroup mapping", ({ I, DT, DTE }) => {
      I.clickCss("#editorAppDTE_Field_editorFields-groupCopyDetails > section > div > div > button.btn-vue-jstree-add");
      I.click(locate('#jsTree .jstree-node.jstree-closed').withText(auto_folder_en).find('.jstree-icon.jstree-ocl'));
      I.click(locate('#jsTree').find('.jstree-node.jstree-leaf').withText(auto_subfolder2_sk).find('a.jstree-anchor'));
-     pause();
-
      DTE.save();
 
      //
@@ -356,6 +354,22 @@ Scenario("multigroup mapping", ({ I, DT, DTE }) => {
      I.seeInField("#editorAppDTE_Field_editorFields-groupCopyDetails div.form-group:nth-child(1) input.form-control", '/' + auto_folder_sk + '/' + auto_subfolder1_sk);
      I.seeInField("#editorAppDTE_Field_editorFields-groupCopyDetails div.form-group:nth-child(2) input.form-control", '/' + auto_folder_sk + '/' + auto_subfolder2_sk);
 
+     //
+     I.say("Remove auto_subfolder1_sk from multigroup mapping");
+     I.clickCss("#editorAppDTE_Field_editorFields-groupCopyDetails div.form-group:nth-child(1) button.btn-vue-jstree-item-remove");
+     DTE.save();
+
+     //
+     I.say("Check if auto_subfolder1_sk is removed from EN version but auto_subfolder2_sk is still there");
+     I.jstreeClick(auto_folder_en);
+     I.wait(1);
+     DT.waitForLoader();
+     I.seeElement(locate('tr').withText(auto_webpage1_sk));
+     I.click(auto_webpage1_sk);
+     DTE.waitForEditor();
+     I.clickCss('#pills-dt-datatableInit-basic-tab');
+     I.dontSeeInField("#editorAppDTE_Field_editorFields-groupCopyDetails div.form-group:nth-child(1) input.form-control", '/' + auto_folder_en + '/' + auto_subfolder1_sk);
+     I.seeInField("#editorAppDTE_Field_editorFields-groupCopyDetails div.form-group:nth-child(1) input.form-control", '/' + auto_folder_en + '/' + auto_subfolder2_sk);
 });
 
 Scenario('vymazanie hlavneho sk priecinka z test priecinka', ({ I, DT, DTE }) => {

--- a/src/test/webapp/tests/webpages/pages-mirroring-wj9.js
+++ b/src/test/webapp/tests/webpages/pages-mirroring-wj9.js
@@ -302,6 +302,40 @@ Scenario('presun stranky webpage1 do podpriecinka sk-mir-subfolder1', ({ I, DT, 
      // presun stranky webpage1 do podpriecinka sk-mir-subfolder1
      wj9MoveSubpage(I, DT, DTE, randomNumber);
 });
+
+Scenario("multigroup mapping", ({ I, DT, DTE }) => {
+     var auto_folder_sk = 'sk-mir-autotest-' + randomNumber;
+     var auto_folder_en = 'en-mir-autotest-' + randomNumber;
+     var auto_subfolder2_sk = 'sk-mir-subfolder2-' + randomNumber;
+     var auto_webpage1_sk = 'sk-multigroup-autotest-' + randomNumber;
+
+     I.jstreeClick(auto_folder_sk);
+     I.click(DT.btn.add_button);
+     DTE.waitForEditor();
+     //I.clickCss("#pills-dt-datatableInit-content-tab");
+     //I.waitForVisible('#cke_1_toolbox');
+     I.clickCss('#pills-dt-datatableInit-basic-tab');
+     I.waitForElement(locate('.col-sm-4.col-form-label').withText('Názov web stránky'));
+     I.fillField('#DTE_Field_title', auto_webpage1_sk);
+
+     I.clickCss("#editorAppDTE_Field_editorFields-groupCopyDetails > section > div > div > button.btn-vue-jstree-add");
+     I.click(locate('#jsTree .jstree-node.jstree-closed').withText(auto_folder_sk).find('.jstree-icon.jstree-ocl'));
+     I.click(locate('#jsTree').find('.jstree-node.jstree-leaf').withText(auto_subfolder1_sk).find('a.jstree-anchor'));
+
+     DTE.save();
+
+     //
+     I.say("Check if multigroup is set in EN version");
+     I.jstreeClick(auto_folder_en);
+     I.wait(1);
+     DT.waitForLoader();
+     I.seeElement(locate('tr.is-not-public').withText(auto_webpage1_sk));
+     I.click(auto_webpage1_sk);
+     DTE.waitForEditor();
+     I.seeInField("#editorAppDTE_Field_editorFields-groupCopyDetails input.form-control", '/' + auto_folder_en + '/' + auto_subfolder1_sk);
+     DTE.cancel();
+});
+
 Scenario('vymazanie hlavneho sk priecinka z test priecinka', ({ I, DT, DTE }) => {
      // vymazanie hlavneho sk priecinka z test priecinka
      wj9DeleteMainFolder(I, DT, DTE, randomNumber);

--- a/src/webjet8/java/sk/iway/iwcm/doc/MultigroupMappingDB.java
+++ b/src/webjet8/java/sk/iway/iwcm/doc/MultigroupMappingDB.java
@@ -168,7 +168,7 @@ public class MultigroupMappingDB
 		{
 			SimpleQuery sq = new SimpleQuery();
 			String sql = "";
-			sql = "SELECT doc_id FROM multigroup_mapping WHERE master_id = ?";
+			sql = "SELECT doc_id FROM multigroup_mapping WHERE master_id = ? ORDER BY doc_id ASC";
 			for(Object o : sq.forList(sql, masterId))
 			{
 				if(o instanceof Number && ((Number)o).intValue() > 0)


### PR DESCRIPTION
Když si založím stránku v adresáři s nastaveným mirroringem (a překladačem), tak se mi v pohodě překlopí do té mutace. Když jí ale následně přidám sekundární adresář, tak se přeložená verze najednou objeví 2x v tom sekundárním adresáři.
 
Přidám stránku do Aktuality: 
image002.jpg
V mutaci se to správně založí 
image004.jpg
CZ stránce přidám sekundární adresář:
image005.jpg
Po uložení se to v CZ mutaci v sekundárním adresáři objeví správně:
image006.jpg
V EN mutaci se ale v sekundárním adresáři objeví stránka 2x a v tom primárním adresáři zmizí
image007.jpg