### PR TITLE
feature/58533-support-for-nonce-in-content-security-policy-header

### DIFF
--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -42,7 +42,8 @@
 
 ### Pre programátora
 
-- Dátové tabuľky - pridaný nový typ poľa `OPTIONS` pre [dynamický zoznam hodnôt](developer/datatables-editor/standard-fields.md#options) v editore. Každý riadok obsahuje dva textové polia (kľúč a hodnota), podporuje pridávanie, odoberanie a zmenu poradia pomocou `drag & drop` (#58517).
+- Dátové tabuľky - pridaný nový typ poľa `OPTIONS`
+- Bezpečnosť - pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` placeholder, automaticky sa vygeneruje unikátny kryptograficky bezpečný nonce a vstrekne sa do všetkých `<script>` značiek v HTML výstupe aj do CSP hlavičky (#TBD). Pridané JUnit testy pre overenie funkcionity (21 testov). pre [dynamický zoznam hodnôt](developer/datatables-editor/standard-fields.md#options) v editore. Každý riadok obsahuje dva textové polia (kľúč a hodnota), podporuje pridávanie, odoberanie a zmenu poradia pomocou `drag & drop` (#58517).
 
 ![](redactor/apps/multistep-form/form-item-editor-advanced.png)
 

--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -37,7 +37,7 @@
 
 ### Bezpečnosť
 
-- Pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` symbol, automaticky sa vygeneruje unikátny kryptograficky bezpečný `nonce` a pridá sa do všetkých `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe aj do `Content-Security-Policy` hlavičky. Inline štýly a skripty sú presunuté na koniec HTML kódu a nastavené pomocou data atribútov (#58533).
+- Pridaná podpora generovania `nonce` pre [Content-Security-Policy](sysadmin/pentests/README.md#content-security-policy-csp) hlavičku (#58533).
 
 ### Dokumentácia
 

--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -43,7 +43,7 @@
 ### Pre programátora
 
 - Dátové tabuľky - pridaný nový typ poľa `OPTIONS` pre [dynamický zoznam hodnôt](developer/datatables-editor/standard-fields.md#options) v editore. Každý riadok obsahuje dva textové polia (kľúč a hodnota), podporuje pridávanie, odoberanie a zmenu poradia pomocou `drag & drop` (#58517).
-- Bezpečnosť - pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` placeholder, automaticky sa vygeneruje unikátny kryptograficky bezpečný nonce a vstrekne sa do všetkých `<script>` značiek v HTML výstupe aj do CSP hlavičky (#58533). Pridané JUnit testy pre overenie funkcionity (21 testov).
+- Bezpečnosť - pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` placeholder, automaticky sa vygeneruje unikátny kryptograficky bezpečný nonce a vstrekne sa do všetkých `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe aj do CSP hlavičky (#58533). Pridané JUnit testy pre overenie funkcionity (31 testov).
 
 ![](redactor/apps/multistep-form/form-item-editor-advanced.png)
 

--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -35,6 +35,10 @@
 - V riadiacej doméne je možné upravovať všetky presmerovania domén.
 - V riadiacej doméne pridaná možnosť zobraziť všetky súbory.
 
+### Bezpečnosť
+
+- Pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` symbol, automaticky sa vygeneruje unikátny kryptograficky bezpečný `nonce` a pridá sa do všetkých `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe aj do `Content-Security-Policy` hlavičky (#58533).
+
 ### Dokumentácia
 
 - Vytvorená nová sekcia [Prehľad nových vlastností](sales/README.md) ktorá obsahuje opisy nových vlastností a **funkcionalít WebJET CMS zrozumiteľným jazykom**, bez zbytočne technických formulácií (#58505).
@@ -43,7 +47,6 @@
 ### Pre programátora
 
 - Dátové tabuľky - pridaný nový typ poľa `OPTIONS` pre [dynamický zoznam hodnôt](developer/datatables-editor/standard-fields.md#options) v editore. Každý riadok obsahuje dva textové polia (kľúč a hodnota), podporuje pridávanie, odoberanie a zmenu poradia pomocou `drag & drop` (#58517).
-- Bezpečnosť - pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` placeholder, automaticky sa vygeneruje unikátny kryptograficky bezpečný nonce a vstrekne sa do všetkých `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe aj do CSP hlavičky (#58533). Pridané JUnit testy pre overenie funkcionity (31 testov).
 
 ![](redactor/apps/multistep-form/form-item-editor-advanced.png)
 

--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -37,7 +37,7 @@
 
 ### Bezpečnosť
 
-- Pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` symbol, automaticky sa vygeneruje unikátny kryptograficky bezpečný `nonce` a pridá sa do všetkých `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe aj do `Content-Security-Policy` hlavičky (#58533). Optimalizovaná vstrekovacia logika: single-pass regex namiesto 3-pass spracovania, StringBuilder namiesto StringBuffer (o 10-15% rýchlejšie), redukcia pamäťových alokácií zo 4 na 2. Opravené dve kritické problémy: CSP hlavička teraz používa správny formát `'nonce-<value>'` (vrátane prefixu a úvodzoviek), nonce sa vstrekne do HTML aj keď je vypnutá funkcia presunu štýlov do hlavičky.
+- Pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` symbol, automaticky sa vygeneruje unikátny kryptograficky bezpečný `nonce` a pridá sa do všetkých `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe aj do `Content-Security-Policy` hlavičky (#58533). Optimalizovaná vstrekovacia logika: single-pass regex namiesto 3-pass spracovania, StringBuilder namiesto StringBuffer (o 10-15% rýchlejšie), redukcia pamäťových alokácií zo 4 na 2. Opravené kritické problémy: CSP hlavička používa správny formát `'nonce-<value>'` (vrátane prefixu a úvodzoviek), nonce sa vstrekne do HTML aj keď je vypnutá funkcia presunu štýlov do hlavičky, detekcia existujúceho nonce používa presnú regulárny výraz na rozlíšenie skutočného atribútu nonce od falošných pozitív (data-nonce, ?nonce= v URL).
 
 ### Dokumentácia
 

--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -42,8 +42,8 @@
 
 ### Pre programátora
 
-- Dátové tabuľky - pridaný nový typ poľa `OPTIONS`
-- Bezpečnosť - pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` placeholder, automaticky sa vygeneruje unikátny kryptograficky bezpečný nonce a vstrekne sa do všetkých `<script>` značiek v HTML výstupe aj do CSP hlavičky (#TBD). Pridané JUnit testy pre overenie funkcionity (21 testov). pre [dynamický zoznam hodnôt](developer/datatables-editor/standard-fields.md#options) v editore. Každý riadok obsahuje dva textové polia (kľúč a hodnota), podporuje pridávanie, odoberanie a zmenu poradia pomocou `drag & drop` (#58517).
+- Dátové tabuľky - pridaný nový typ poľa `OPTIONS` pre [dynamický zoznam hodnôt](developer/datatables-editor/standard-fields.md#options) v editore. Každý riadok obsahuje dva textové polia (kľúč a hodnota), podporuje pridávanie, odoberanie a zmenu poradia pomocou `drag & drop` (#58517).
+- Bezpečnosť - pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` placeholder, automaticky sa vygeneruje unikátny kryptograficky bezpečný nonce a vstrekne sa do všetkých `<script>` značiek v HTML výstupe aj do CSP hlavičky (#58533). Pridané JUnit testy pre overenie funkcionity (21 testov).
 
 ![](redactor/apps/multistep-form/form-item-editor-advanced.png)
 

--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -37,7 +37,7 @@
 
 ### Bezpečnosť
 
-- Pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` symbol, automaticky sa vygeneruje unikátny kryptograficky bezpečný `nonce` a pridá sa do všetkých `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe aj do `Content-Security-Policy` hlavičky (#58533). Optimalizovaná vstrekovacia logika: single-pass regex namiesto 3-pass spracovania, StringBuilder namiesto StringBuffer (o 10-15% rýchlejšie), redukcia pamäťových alokácií zo 4 na 2. Opravené kritické problémy: CSP hlavička používa správny formát `'nonce-<value>'` (vrátane prefixu a úvodzoviek), nonce sa vstrekne do HTML aj keď je vypnutá funkcia presunu štýlov do hlavičky, detekcia existujúceho nonce používa presnú regulárny výraz na rozlíšenie skutočného atribútu nonce od falošných pozitív (data-nonce, ?nonce= v URL).
+- Pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` symbol, automaticky sa vygeneruje unikátny kryptograficky bezpečný `nonce` a pridá sa do všetkých `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe aj do `Content-Security-Policy` hlavičky. Inline štýly a skripty sú presunuté na koniec HTML kódu a nastavené pomocou data atribútov (#58533).
 
 ### Dokumentácia
 

--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -37,7 +37,7 @@
 
 ### Bezpečnosť
 
-- Pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` symbol, automaticky sa vygeneruje unikátny kryptograficky bezpečný `nonce` a pridá sa do všetkých `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe aj do `Content-Security-Policy` hlavičky (#58533).
+- Pridaná podpora generovania `nonce` pre `Content-Security-Policy` hlavičku. Ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` symbol, automaticky sa vygeneruje unikátny kryptograficky bezpečný `nonce` a pridá sa do všetkých `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe aj do `Content-Security-Policy` hlavičky (#58533). Optimalizovaná vstrekovacia logika: single-pass regex namiesto 3-pass spracovania, StringBuilder namiesto StringBuffer (o 10-15% rýchlejšie), redukcia pamäťových alokácií zo 4 na 2. Opravené dve kritické problémy: CSP hlavička teraz používa správny formát `'nonce-<value>'` (vrátane prefixu a úvodzoviek), nonce sa vstrekne do HTML aj keď je vypnutá funkcia presunu štýlov do hlavičky.
 
 ### Dokumentácia
 

--- a/docs/sk/ROADMAP.md
+++ b/docs/sk/ROADMAP.md
@@ -26,6 +26,7 @@ Vysvetlenie použitých piktogramov:
 - [ ] Zmazať pridružené súbory k web stránke keď ju zmažem - spýtať sa ale vopred používateľa, či súbory chce zmazať. Kontrolovať, či sa nepoužívajú niekde inde.
 - [ ] Mazanie dát - pridať možnosť mazať stránky a priečinky z koša. Vyriešiť aj možnosť mazanie dát spúšťať ako automatizovanú úlohu.
 - [ ] Nepoužívané súbory - spraviť možnosť získať zoznam nepoužívaných súborov - nikde v stránke sa nepoužívajú, ani v médiach atď. Bola na to API `FileTools.getDirFileUsage(currentDir, request)`. Pridať ako kartu do vlastností priečinka v prieskumníku.
+- [ ] Prieskumník - zamedziť prácu s priečinku pre Manažér dokumentov, aby sa so súbormi nedalo manipulovať mimo Manažér dokumentov.
 
 ## 2025
 

--- a/docs/sk/ROADMAP.md
+++ b/docs/sk/ROADMAP.md
@@ -45,7 +45,7 @@ Vysvetlenie použitých piktogramov:
 - [ ] `quill` - pridať možnosť nastaviť položky menu vrátane farieb.
 - [ ] Aplikácie - možnosť nákupu aplikácie pre OpenSource verziu (#55825).
 - [ ] Možnosť vykonať Thymeleaf kód v hlavičke/pätičke a možno aj v tele web stránky.
-- [ ] Bezpečnosť - pridať podporu generovania `nonce` pre `Content-Security-Policy` hlavičku, viď napr. https://medium.com/@ooutofmind/enhancing-web-security-implementing-csp-nonce-mechanism-with-spring-cloud-gateway-a5f206d69aee.
+- [x] Bezpečnosť - pridať podporu generovania `nonce` pre `Content-Security-Policy` hlavičku, viď napr. https://medium.com/@ooutofmind/enhancing-web-security-implementing-csp-nonce-mechanism-with-spring-cloud-gateway-a5f206d69aee. (#TBD)
 - [x] Formuláre - pridať možnosť volať Java triedu pre validáciu formuláru (#58161).
 - [x] Značky - filtrovať podľa aktuálnej domény aby to bolo rovnaké ako v iných častiach (#57837).
 - [x] Import používateľov - ak nie je zadané heslo, tak vygenerovať (pre nových používateľov), ak nie je posielaný stav `authorized` nastaviť na `true` (#58253).

--- a/docs/sk/ROADMAP.md
+++ b/docs/sk/ROADMAP.md
@@ -45,7 +45,7 @@ Vysvetlenie použitých piktogramov:
 - [ ] `quill` - pridať možnosť nastaviť položky menu vrátane farieb.
 - [ ] Aplikácie - možnosť nákupu aplikácie pre OpenSource verziu (#55825).
 - [ ] Možnosť vykonať Thymeleaf kód v hlavičke/pätičke a možno aj v tele web stránky.
-- [x] Bezpečnosť - pridať podporu generovania `nonce` pre `Content-Security-Policy` hlavičku, viď napr. https://medium.com/@ooutofmind/enhancing-web-security-implementing-csp-nonce-mechanism-with-spring-cloud-gateway-a5f206d69aee. (#TBD)
+- [x] Bezpečnosť - pridať podporu generovania `nonce` pre `Content-Security-Policy` hlavičku, viď napr. https://medium.com/@ooutofmind/enhancing-web-security-implementing-csp-nonce-mechanism-with-spring-cloud-gateway-a5f206d69aee. (#58533)
 - [x] Formuláre - pridať možnosť volať Java triedu pre validáciu formuláru (#58161).
 - [x] Značky - filtrovať podľa aktuálnej domény aby to bolo rovnaké ako v iných častiach (#57837).
 - [x] Import používateľov - ak nie je zadané heslo, tak vygenerovať (pre nových používateľov), ak nie je posielaný stav `authorized` nastaviť na `true` (#58253).

--- a/docs/sk/sysadmin/pentests/README.md
+++ b/docs/sk/sysadmin/pentests/README.md
@@ -142,7 +142,7 @@ V starších inštaláciách bolo možné nastaviť HTTP hlavičky aj cez konf. 
 
 Hodnoty nastavené cez konf. premennú `responseHeaders` sú globálne bez ohľadu na aktuálnu doménu.
 
-### Content-Security-Policy (CSP) {#content-security-policy-csp}
+### Content-Security-Policy (CSP)
 
 [Content-Security-Policy (CSP)](https://content-security-policy.com) je bezpečnostná hlavička, ktorá definuje pravidlá pre načítanie zdrojov (skripty, štýly, obrázky, frame-ancestors atď.) na stránke. CSP výrazne znižuje riziko XSS útokov tým, že obmedzuje, odkiaľ môžu byť zdroje načítané a aký kód sa smie vykonávať.
 

--- a/docs/sk/sysadmin/pentests/README.md
+++ b/docs/sk/sysadmin/pentests/README.md
@@ -106,7 +106,7 @@ Môžete skontrolovať ešte nasledovné konf. premenné:
 
 V aplikácii Konfigurácia môžete nastaviť hodnoty bezpečnostných hlavičiek:
 
-- `contentSecurityPolicy` - nastavenie hlavičky `Content-Security-Policy`. Obmedzenie ako má stránka načítavať rôzne zdroje. Ak chcete povoliť generovanie CSP nonce pre `<script>` značky, musíte do konfigurácie pridať `{nonce}` placeholder. System automaticky vygeneruje unikátny nonce pre každú požiadavku a vstrekne ho do všetkých `<script>` značiek v HTML výstupe aj do CSP hlavičky.
+- `contentSecurityPolicy` - nastavenie hlavičky `Content-Security-Policy`. Obmedzenie ako má stránka načítavať rôzne zdroje. Ak chcete povoliť generovanie CSP nonce pre HTML výstup, musíte do konfigurácie pridať `{nonce}` placeholder. System automaticky vygeneruje unikátny kryptograficky bezpečný nonce pre každú požiadavku a vstrekne ho do všetkých `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe aj do CSP hlavičky.
 
   Odporúčaná hodnota pre https stránku s nonce:
 
@@ -114,7 +114,7 @@ V aplikácii Konfigurácia môžete nastaviť hodnoty bezpečnostných hlavičie
   default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https: 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self'; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'
   ```
 
-  V hodnote `{nonce}` nahradí systém reálny nonce (napr. `abc123...`). Bez `{nonce}` sa nonce negeneruje. Pre svg stránky sa používa samostatná konfigurácia `contentSecurityPolicySvg`. Predvolene prázdne (hlavička sa nenastavuje).
+  System nahradí `{nonce}` hodnotou `'nonce-<base64-value>'` (vrátane úvodzoviek a prefixu `nonce-`). Napríklad ak systém vygeneruje nonce `abc123xyz`, do CSP hlavičky sa vloží `'nonce-abc123xyz'`. Bez `{nonce}` sa nonce negeneruje. Pre svg stránky sa používa samostatná konfigurácia `contentSecurityPolicySvg`. Predvolene prázdne (hlavička sa nenastavuje).
 - `contentSecurityPolicySvg` - špecifické obmedzenie pre SVG obrázky z dôvodu ich iného spracovania v Internet Explorer.
 - `featurePolicyHeader` - hodnota HTTP hlavičky `Feature-Policy/Permissions-Policy` (napr.: `microphone 'none'; geolocation 'none'`), viac na: https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy. Predvolene prázdne.
 - `refererPolicy` - nastavenie HTTP hlavičky `Referrer-Policy`, odporúčame nastaviť na hodnotu `same-origin`. Predvolene `same-origin`.

--- a/docs/sk/sysadmin/pentests/README.md
+++ b/docs/sk/sysadmin/pentests/README.md
@@ -159,10 +159,14 @@ Ak chcete povoliť generovanie CSP nonce pre HTML výstup, musíte do konfigurá
 Odporúčaná hodnota pre https stránku s nonce:
 
 ```txt
-default-src 'self'; script-src 'self' {nonce} https: 'strict-dynamic'; style-src 'self' https: {nonce}; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self' www.youtube.com docs.google.com; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';
+default-src 'self'; script-src 'self' {nonce} https: 'strict-dynamic'; style-src 'self' https: 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self' www.youtube.com docs.google.com; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';
 ```
 
-System nahradí `{nonce}` hodnotou `'nonce-<base64-value>'` (vrátane úvodzoviek a prefixu `nonce-`). Bez `{nonce}` sa nonce negeneruje. Pre svg stránky sa používa samostatná konfigurácia `contentSecurityPolicySvg`. Predvolene prázdne (hlavička sa nenastavuje).
+System nahradí `{nonce}` hodnotou `'nonce-<base64-value>'` (vrátane úvodzoviek a prefixu `nonce-`). Bez `{nonce}` sa nonce negeneruje. Pre svg stránky sa používa samostatná konfigurácia `contentSecurityPolicySvg`. Predvolene prázdne (hlavička sa nenastavuje). V príklade je povolená možnosť `strict-dynamic` pre dynamické vkladanie skriptov pri volaní REST služieb a `unsafe-inline` pre inline štýly. Toto je nastavenie, ktoré chráni pomocou `nonce` pred bežnými útokmi. Pre väčšie zabezpečenie môžete tieto možnosti zrušiť a aktivovať `{nonce}` aj pre `style-src` ale má to výraznejšie dopady na funkčnosť stránky.
+
+Akákoľvek zmena v nastavení CSP hlavičky vyžaduje intenzívne testovanie funkčnosti web sídla.
+
+Pri použití `nonce` sa CSP hlavička nenastavuje pre administráciu, pretože by to malo výrazný dopad na jej funkčnosť.
 
 #### Ako funguje nonce
 

--- a/docs/sk/sysadmin/pentests/README.md
+++ b/docs/sk/sysadmin/pentests/README.md
@@ -152,9 +152,9 @@ Základná možnosť bez použitia `nonce` atribútu:
 default-src 'none'; script-src https: blob: data: 'unsafe-inline' 'unsafe-eval'; worker-src https: blob:; child-src https: blob:; style-src https: data: 'unsafe-inline' 'unsafe-eval'; img-src https: data: 'unsafe-inline'; font-src https: data:; object-src blob: 'self'; base-uri 'none'; frame-ancestors 'self'; connect-src blob: 'self'; frame-src 'self';
 ```
 
-WebJET CMS podporuje generovanie dynamických CSP nonce — jednorazových kryptografických hodnôt, ktoré sa generujú pre každú HTTP požiadavku. Nonce sa vstrekne do `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe a zároveň sa nahradí v CSP hlavičke.
+WebJET CMS podporuje generovanie dynamických CSP nonce — jednorazových kryptografických hodnôt, ktoré sa generujú pre každú HTTP požiadavku. Nonce sa vloží do `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe a zároveň sa nahradí v CSP hlavičke.
 
-Ak chcete povoliť generovanie CSP nonce pre HTML výstup, musíte do konfigurácie pridať `{nonce}` placeholder. System automaticky vygeneruje unikátny kryptograficky bezpečný nonce pre každú požiadavku a vstrekne ho do HTML výstupe aj do CSP hlavičky.
+Ak chcete povoliť generovanie CSP nonce pre HTML výstup, musíte do konfigurácie pridať `{nonce}` placeholder. System automaticky vygeneruje unikátny kryptograficky bezpečný nonce pre každú požiadavku a vloží ho do HTML výstupu aj do CSP hlavičky.
 
 Odporúčaná hodnota pre https stránku s nonce:
 
@@ -172,7 +172,7 @@ Pri použití `nonce` sa CSP hlavička nenastavuje pre administráciu, pretože 
 
 1. Pri každej požiadavke systém vygeneruje 16-bytový náhodný hodnotu pomocou `SecureRandom`
 2. Hodnota sa zakóduje do Base64 a uloží sa do `RequestBean.cspNonce`
-3. V HTML výstupe sa nonce vstrekne do `<script nonce="...">`, `<style nonce="...">` a `<link nonce="...">` značiek
+3. V HTML výstupe sa nonce vloží do `<script nonce="...">`, `<style nonce="...">` a `<link nonce="...">` značiek
 4. V CSP hlavičke sa `{nonce}` placeholder v konfigurácii nahradí za `'nonce-<base64-value>'`
 5. Prehliadač povoľuje vykonanie inline skriptu/štýlu iba ak má správny nonce
 
@@ -180,7 +180,7 @@ Pri použití `nonce` sa CSP hlavička nenastavuje pre administráciu, pretože 
 
 Nonce sa generuje iba vtedy, ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` placeholder. Ak nonce nie je potrebné (napr. stránka nepoužíva inline skripty), stačí `{nonce}` z konfigurácie odstrániť — systém nonce negeneruje a nepreťažuje server.
 
-Nonce sa automaticky vstrekne do týchto HTML prvkov:
+Nonce sa automaticky vloží do týchto HTML prvkov:
 
 - `<script>` — inline JavaScript kód
 - `<style>` — inline CSS štýly
@@ -188,19 +188,17 @@ Nonce sa automaticky vstrekne do týchto HTML prvkov:
 
 #### Povolenie unsafe-inline pre štýly
 
-Ak vaša stránka používa inline `style` atribúty na HTML prvkoch (napr. `<div style="color: red;">`), musíte do `style-src` pridať `unsafe-inline`. WebJET CMS automaticky spracuje tieto inline štýly a presunie ich do `<style nonce="...">` bloku v hlavičke stránky.
+Ak vaša stránka používa inline `style` atribúty na HTML prvkoch (napr. `<div style="color: red;">`), tak pri použití `nonce` spracuje tieto inline štýly a presunie ich do `<style nonce="...">` bloku v hlavičke stránky.
 
-Príklad konfigurácie s povoleným `unsafe-inline` pre štýly:
+Ak nepoužijete `nonce` pridajte `unsafe-inline` pre povolenie inline štýlov. v stránke:
 
 ```txt
-style-src 'self' {nonce} https: 'unsafe-inline'
+style-src 'self' https: 'unsafe-inline'
 ```
-
-Bez `unsafe-inline` by bolo potrebné odstrániť všetky inline `style` atribúty z HTML výstupu.
 
 #### Povolenie unsafe-inline pre skripty
 
-Ak je v `script-src` prítomné `unsafe-inline`, systém **nevstrekne** nonce do `<script>` značiek a **nespracováva** inline udalosti (`onclick`, `onmouseover` atď.). To je vhodné pre stránky, ktoré majú veľa inline JavaScriptu a nechcú sa spoliehať na nonce.
+Ak je v `script-src` prítomné `unsafe-inline`, systém **nevloží** nonce do `<script>` značiek a **nespracováva** inline udalosti (`onclick`, `onmouseover` atď.). To je vhodné pre stránky, ktoré majú veľa inline JavaScriptu a nechcú sa spoliehať na nonce.
 
 Príklad konfigurácie s `unsafe-inline` pre skripty:
 

--- a/docs/sk/sysadmin/pentests/README.md
+++ b/docs/sk/sysadmin/pentests/README.md
@@ -106,15 +106,7 @@ Môžete skontrolovať ešte nasledovné konf. premenné:
 
 V aplikácii Konfigurácia môžete nastaviť hodnoty bezpečnostných hlavičiek:
 
-- `contentSecurityPolicy` - nastavenie hlavičky `Content-Security-Policy`. Obmedzenie ako má stránka načítavať rôzne zdroje. Ak chcete povoliť generovanie CSP nonce pre HTML výstup, musíte do konfigurácie pridať `{nonce}` placeholder. System automaticky vygeneruje unikátny kryptograficky bezpečný nonce pre každú požiadavku a vstrekne ho do všetkých `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe aj do CSP hlavičky.
-
-  Odporúčaná hodnota pre https stránku s nonce:
-
-  ```txt
-  default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https: 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self'; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'
-  ```
-
-  System nahradí `{nonce}` hodnotou `'nonce-<base64-value>'` (vrátane úvodzoviek a prefixu `nonce-`). Napríklad ak systém vygeneruje nonce `abc123xyz`, do CSP hlavičky sa vloží `'nonce-abc123xyz'`. Bez `{nonce}` sa nonce negeneruje. Pre svg stránky sa používa samostatná konfigurácia `contentSecurityPolicySvg`. Predvolene prázdne (hlavička sa nenastavuje).
+- `contentSecurityPolicy` - nastavenie hlavičky `Content-Security-Policy`. Obmedzenie ako má stránka načítavať rôzne zdroje. Viac informácií v sekcii [Content-Security-Policy (CSP)](#content-security-policy-csp).
 - `contentSecurityPolicySvg` - špecifické obmedzenie pre SVG obrázky z dôvodu ich iného spracovania v Internet Explorer.
 - `featurePolicyHeader` - hodnota HTTP hlavičky `Feature-Policy/Permissions-Policy` (napr.: `microphone 'none'; geolocation 'none'`), viac na: https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy. Predvolene prázdne.
 - `refererPolicy` - nastavenie HTTP hlavičky `Referrer-Policy`, odporúčame nastaviť na hodnotu `same-origin`. Predvolene `same-origin`.
@@ -149,6 +141,138 @@ V starších inštaláciách bolo možné nastaviť HTTP hlavičky aj cez konf. 
 ```
 
 Hodnoty nastavené cez konf. premennú `responseHeaders` sú globálne bez ohľadu na aktuálnu doménu.
+
+### Content-Security-Policy (CSP) {#content-security-policy-csp}
+
+[Content-Security-Policy (CSP)](https://content-security-policy.com) je bezpečnostná hlavička, ktorá definuje pravidlá pre načítanie zdrojov (skripty, štýly, obrázky, frame-ancestors atď.) na stránke. CSP výrazne znižuje riziko XSS útokov tým, že obmedzuje, odkiaľ môžu byť zdroje načítané a aký kód sa smie vykonávať.
+
+Základná možnosť bez použitia `nonce` atribútu:
+
+```txt
+default-src 'none'; script-src https: blob: data: 'unsafe-inline' 'unsafe-eval'; worker-src https: blob:; child-src https: blob:; style-src https: data: 'unsafe-inline' 'unsafe-eval'; img-src https: data: 'unsafe-inline'; font-src https: data:; object-src blob: 'self'; base-uri 'none'; frame-ancestors 'self'; connect-src blob: 'self'; frame-src 'self';
+```
+
+WebJET CMS podporuje generovanie dynamických CSP nonce — jednorazových kryptografických hodnôt, ktoré sa generujú pre každú HTTP požiadavku. Nonce sa vstrekne do `<script>`, `<style>` a `<link rel="stylesheet">` značiek v HTML výstupe a zároveň sa nahradí v CSP hlavičke.
+
+Ak chcete povoliť generovanie CSP nonce pre HTML výstup, musíte do konfigurácie pridať `{nonce}` placeholder. System automaticky vygeneruje unikátny kryptograficky bezpečný nonce pre každú požiadavku a vstrekne ho do HTML výstupe aj do CSP hlavičky.
+
+Odporúčaná hodnota pre https stránku s nonce:
+
+```txt
+default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https: 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self'; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'
+```
+
+System nahradí `{nonce}` hodnotou `'nonce-<base64-value>'` (vrátane úvodzoviek a prefixu `nonce-`). Bez `{nonce}` sa nonce negeneruje. Pre svg stránky sa používa samostatná konfigurácia `contentSecurityPolicySvg`. Predvolene prázdne (hlavička sa nenastavuje).
+
+#### Ako funguje nonce
+
+1. Pri každej požiadavke systém vygeneruje 16-bytový náhodný hodnotu pomocou `SecureRandom`
+2. Hodnota sa zakóduje do Base64 a uloží sa do `RequestBean.cspNonce`
+3. V HTML výstupe sa nonce vstrekne do `<script nonce="...">`, `<style nonce="...">` a `<link nonce="...">` značiek
+4. V CSP hlavičke sa `{nonce}` placeholder v konfigurácii nahradí za `'nonce-<base64-value>'`
+5. Prehliadač povoľuje vykonanie inline skriptu/štýlu iba ak má správny nonce
+
+#### Konfigurácia nonce — čo sa má spracovávať
+
+Nonce sa generuje iba vtedy, ak konfigurácia `contentSecurityPolicy` obsahuje `{nonce}` placeholder. Ak nonce nie je potrebné (napr. stránka nepoužíva inline skripty), stačí `{nonce}` z konfigurácie odstrániť — systém nonce negeneruje a nepreťažuje server.
+
+Nonce sa automaticky vstrekne do týchto HTML prvkov:
+
+- `<script>` — inline JavaScript kód
+- `<style>` — inline CSS štýly
+- `<link rel="stylesheet">` — externé tabuľky štýlov
+
+#### Povolenie unsafe-inline pre štýly
+
+Ak vaša stránka používa inline `style` atribúty na HTML prvkoch (napr. `<div style="color: red;">`), musíte do `style-src` pridať `unsafe-inline`. WebJET CMS automaticky spracuje tieto inline štýly a presunie ich do `<style nonce="...">` bloku v hlavičke stránky.
+
+Príklad konfigurácie s povoleným `unsafe-inline` pre štýly:
+
+```txt
+style-src 'self' {nonce} https: 'unsafe-inline'
+```
+
+Bez `unsafe-inline` by bolo potrebné odstrániť všetky inline `style` atribúty z HTML výstupu.
+
+#### Povolenie unsafe-inline pre skripty
+
+Ak je v `script-src` prítomné `unsafe-inline`, systém **nevstrekne** nonce do `<script>` značiek a **nespracováva** inline udalosti (`onclick`, `onmouseover` atď.). To je vhodné pre stránky, ktoré majú veľa inline JavaScriptu a nechcú sa spoliehať na nonce.
+
+Príklad konfigurácie s `unsafe-inline` pre skripty:
+
+```txt
+script-src 'self' 'unsafe-inline'
+```
+
+V tomto prípade sa do CSP hlavičky **nevloží** `nonce-` hodnota pre skripty, pretože `unsafe-inline` už povoľuje všetky inline skripty.
+
+#### Čiastočné použitie nonce (len skripty, bez štýlov)
+
+Ak chcete použiť nonce iba pre skripty a pre štýly ponechať `unsafe-inline`:
+
+```txt
+script-src 'self' {nonce}; style-src 'self' 'unsafe-inline'
+```
+
+V tomto prípade:
+
+- `<script>` značky dostanú `nonce` atribút
+- `<style>` značky **nedostanú** `nonce` (pretože `style-src` má `unsafe-inline`)
+- Inline `style` atribúty na HTML prvkoch sa **nespracovávajú** (pretože `style-src` má `unsafe-inline`)
+
+#### Čiastočné použitie nonce (len štýly, bez skriptov)
+
+Ak chcete použiť nonce iba pre štýly a pre skripty ponechať `unsafe-inline`:
+
+```txt
+script-src 'self' 'unsafe-inline'; style-src 'self' {nonce}
+```
+
+V tomto prípade:
+
+- `<script>` značky **nedostanú** `nonce` (pretože `script-src` má `unsafe-inline`)
+- `<style>` značky dostanú `nonce` atribút
+- Inline `style` atribúty na HTML prvkoch sa presunú do `<style nonce="...">` bloku v hlavičke
+
+#### Spracovanie inline udalostí
+
+Ak `script-src` **neobsahuje** `unsafe-inline`, WebJET CMS automaticky spracuje inline udalosti (`onclick`, `onmouseover`, `onmouseout`, `onfocus`, `onblur`, `onkeydown`, `onkeyup`, `onsubmit`, `onchange`, `oninput`, `ondblclick`, `oncontextmenu`, `ondrag`, `ondrop`) na HTML prvkoch. Udalosti sa nahradia za `data-inline-*` atribúty a JavaScript kód na ich obnovenie sa vloží do `<script nonce="...">` bloku v `</body>`.
+
+Príklad transformácie:
+
+```html
+<!-- Pred spracovaním -->
+<button onclick="alert('hello')">Klikni</button>
+
+<!-- Po spracovaní -->
+<button data-inline-onclick="nonce1">Klikni</button>
+<script nonce="abc123">
+    document.querySelectorAll('[data-inline-onclick="nonce1"]').forEach(function(el) {
+        el.onclick = function(event) {alert('hello');};
+    });
+</script>
+```
+
+#### Odporúčania pre CSP konfiguráciu
+
+1. **Používajte `default-src 'none'`** ako základ — nezakazuje nič, ale je explicitný
+2. **Povoľujte iba potrebné zdroje** — napr. `script-src 'self' {nonce} https:` len pre vlastné domény a HTTPS
+3. **Používajte `{nonce}` namiesto `unsafe-inline`** pre skripty — je bezpečnejšie, pretože nonce sa mení pri každej požiadavke
+4. **Povoľte `unsafe-inline` pre štýly** len ak je to nevyhnutné — inline štýly sú bežnejšie a ťažšie sa odstránia
+5. **Nastavte `frame-ancestors 'self'`** na zabránenie `clickjacking`
+6. **Používajte `form-action 'self'`** na obmedzenie odosielania formulárov
+7. **Nastavte `base-uri 'self'`** na zabránenie zmeny `<base>` elementu útočníkom
+8. **Používajte `contentSecurityPolicySvg`** pre SVG súbory — SVG môžu obsahovať JavaScript, ktorý CSP obmedzí
+
+#### Otestovanie CSP konfigurácie
+
+Po zmene CSP konfigurácie otestujte stránku v konzole prehliadača (F12 → Console). Ak sú zdroje blokované, uvidíte hlásenia typu:
+
+```txt
+Refused to execute inline script because it violates the following Content Security Policy directive
+```
+
+Tieto hlásenia znamenajú, že stránka obsahuje inline kód, ktorý CSP neumožňuje. Riešením je buď pridať príslušný zdroj do CSP direktívy, alebo použiť nonce.
 
 ### Pravidlá hesiel
 

--- a/docs/sk/sysadmin/pentests/README.md
+++ b/docs/sk/sysadmin/pentests/README.md
@@ -106,7 +106,15 @@ Môžete skontrolovať ešte nasledovné konf. premenné:
 
 V aplikácii Konfigurácia môžete nastaviť hodnoty bezpečnostných hlavičiek:
 
-- `contentSecurityPolicy` - nastavenie hlavičky `Content-Security-Policy`. Obmedzenie ako má stránka načítavať rôzne zdroje. Ak máte httpS certifikát môžete nastaviť na hodnotu: `default-src 'none'; script-src https: blob: data: 'unsafe-inline' 'unsafe-eval'; worker-src https: blob:; child-src https: blob:; style-src https: data: 'unsafe-inline' 'unsafe-eval'; img-src https: data: 'unsafe-inline'; font-src https: data:; object-src blob: 'self'; base-uri 'none'; frame-ancestors 'self'; connect-src blob: 'self'; frame-src 'self'`. Predvolene prázdne (hlavička sa nenastavuje).
+- `contentSecurityPolicy` - nastavenie hlavičky `Content-Security-Policy`. Obmedzenie ako má stránka načítavať rôzne zdroje. Ak chcete povoliť generovanie CSP nonce pre `<script>` značky, musíte do konfigurácie pridať `{nonce}` placeholder. System automaticky vygeneruje unikátny nonce pre každú požiadavku a vstrekne ho do všetkých `<script>` značiek v HTML výstupe aj do CSP hlavičky.
+
+  Odporúčaná hodnota pre https stránku s nonce:
+
+  ```
+  default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https: 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self'; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'
+  ```
+
+  V hodnote `{nonce}` nahradí systém reálny nonce (napr. `abc123...`). Bez `{nonce}` sa nonce negeneruje. Pre svg stránky sa používa samostatná konfigurácia `contentSecurityPolicySvg`. Predvolene prázdne (hlavička sa nenastavuje).
 - `contentSecurityPolicySvg` - špecifické obmedzenie pre SVG obrázky z dôvodu ich iného spracovania v Internet Explorer.
 - `featurePolicyHeader` - hodnota HTTP hlavičky `Feature-Policy/Permissions-Policy` (napr.: `microphone 'none'; geolocation 'none'`), viac na: https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy. Predvolene prázdne.
 - `refererPolicy` - nastavenie HTTP hlavičky `Referrer-Policy`, odporúčame nastaviť na hodnotu `same-origin`. Predvolene `same-origin`.

--- a/docs/sk/sysadmin/pentests/README.md
+++ b/docs/sk/sysadmin/pentests/README.md
@@ -159,7 +159,7 @@ Ak chcete povoliť generovanie CSP nonce pre HTML výstup, musíte do konfigurá
 Odporúčaná hodnota pre https stránku s nonce:
 
 ```txt
-default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https: 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self'; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'
+default-src 'self'; script-src 'self' {nonce} https: 'strict-dynamic'; style-src 'self' https: {nonce}; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self' www.youtube.com docs.google.com; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';
 ```
 
 System nahradí `{nonce}` hodnotou `'nonce-<base64-value>'` (vrátane úvodzoviek a prefixu `nonce-`). Bez `{nonce}` sa nonce negeneruje. Pre svg stránky sa používa samostatná konfigurácia `contentSecurityPolicySvg`. Predvolene prázdne (hlavička sa nenastavuje).
@@ -252,6 +252,57 @@ Príklad transformácie:
     });
 </script>
 ```
+
+#### Povolenie pomocou hash (CSP hashes)
+
+Okrem nonce umožňuje CSP aj povoľovanie inline skriptov a štýlov pomocou kryptografických hash. Do CSP direktívy sa vloží hodnota `sha256-<base64-hash>`, `sha384-<base64-hash>` alebo `sha512-<base64-hash>`, kde hash zodpovedá obsahu konkrétneho `<script>` alebo `<style>` elementu.
+
+Príklad — ak máte na stránke inline skript:
+
+```html
+<script>console.log('ahoj');</script>
+```
+
+Vypočítajte SHA-256 hash obsahu skriptu (vrátane medzier a nových riadkov):
+
+```bash
+echo -n "console.log('ahoj');" | openssl dgst -sha256 -binary | base64
+```
+
+Výsledný hash pridajte do CSP konfigurácie:
+
+```txt
+script-src 'self' 'sha256-<vypočítaný-hash>'; style-src 'self' 'sha384-<hash-štýlu>'
+```
+
+**Výhody hash oproti nonce:**
+
+- Statické — hash sa nemení medzi požiadavkami, nie je potrebné generovať nonce
+- Jednoduchšie na konfiguráciu pre stabilný inline kód
+
+**Kedy použiť hash namiesto nonce:**
+
+- Pre malé, stabilné inline skripty/štýly, ktoré sa zriedka menia
+- Pre skripty tretích strán, ktoré nie je možné modifikovať
+- Ako doplnok k nonce pre špecifické prípady, kde nonce nie je dostupné
+
+**Kombinácia nonce a hash:**
+
+Je možné použiť obe metódy súčasne:
+
+```txt
+script-src 'self' {nonce} 'sha256-xyz123...'; style-src 'self' {nonce} 'sha384-abc456...'
+```
+
+V tomto prípade:
+
+- Dynamické inline skripty s `nonce` atribútom budú fungovať
+- Stabilné inline skripty s platným hash budú fungovať aj bez `nonce`
+- Ak sa hash zmení, skript sa prestane vykonávať, kým sa neaktualizuje CSP konfigurácia
+
+#### Povolenie pre vkladané skripty
+
+Ak vkladáte skripty dynamicky volaním REST služieb pridajte do povolení pre `script-src` hodnotu `'strict-dynamic'`.
 
 #### Odporúčania pre CSP konfiguráciu
 

--- a/docs/sk/sysadmin/pentests/README.md
+++ b/docs/sk/sysadmin/pentests/README.md
@@ -110,7 +110,7 @@ V aplikácii Konfigurácia môžete nastaviť hodnoty bezpečnostných hlavičie
 
   Odporúčaná hodnota pre https stránku s nonce:
 
-  ```
+  ```txt
   default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https: 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self'; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'
   ```
 

--- a/src/main/java/sk/iway/iwcm/Constants.java
+++ b/src/main/java/sk/iway/iwcm/Constants.java
@@ -1518,7 +1518,7 @@ public class Constants {
 				"Ak je true nebude elfinder ziskavat last modified, size a nebude sa kontrolovat, ci priecinky maju podpriecinky(bude sa predpokladat, ze ano)");
 
 		setString("contentSecurityPolicy", "", MOD_SECURITY,
-				"Obmedzenie ako stránka ma stranka nacitavat rôzne zdroje, ak mate httpS certifikat odporucame nastavit na hodnotu: default-src 'self'; script-src 'self' {nonce} https: 'strict-dynamic'; style-src 'self' https: {noAnce} 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self' www.youtube.com docs.google.com; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';");
+				"Obmedzenie ako stránka ma stranka nacitavat rôzne zdroje, ak mate httpS certifikat odporucame nastavit na hodnotu: default-src 'self'; script-src 'self' {nonce} https: 'strict-dynamic'; style-src 'self' https: 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self' www.youtube.com docs.google.com; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';");
 		setString("contentSecurityPolicySvg", "default-src 'self' 'unsafe-inline'", MOD_SECURITY,
 				"Obmedzenie pre SVG obrazky, ktore mozu obsahovat vlozeny javascript kod, odporucame nastavit na hodnotu: default-src 'self' 'unsafe-inline'");
 		setString("refererPolicy", "same-origin", MOD_SECURITY,

--- a/src/main/java/sk/iway/iwcm/Constants.java
+++ b/src/main/java/sk/iway/iwcm/Constants.java
@@ -1518,7 +1518,7 @@ public class Constants {
 				"Ak je true nebude elfinder ziskavat last modified, size a nebude sa kontrolovat, ci priecinky maju podpriecinky(bude sa predpokladat, ze ano)");
 
 		setString("contentSecurityPolicy", "", MOD_SECURITY,
-				"Obmedzenie ako stránka ma stranka nacitavat rôzne zdroje, ak mate httpS certifikat odporucame nastavit na hodnotu: default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https: 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self'; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';");
+				"Obmedzenie ako stránka ma stranka nacitavat rôzne zdroje, ak mate httpS certifikat odporucame nastavit na hodnotu: default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https: 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self'; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; (Poznámka: {nonce} sa nahradí hodnotou 'nonce-<base64-value>' (vrátane úvodzoviek)");
 		setString("contentSecurityPolicySvg", "default-src 'self' 'unsafe-inline'", MOD_SECURITY,
 				"Obmedzenie pre SVG obrazky, ktore mozu obsahovat vlozeny javascript kod, odporucame nastavit na hodnotu: default-src 'self' 'unsafe-inline'");
 		setString("refererPolicy", "same-origin", MOD_SECURITY,

--- a/src/main/java/sk/iway/iwcm/Constants.java
+++ b/src/main/java/sk/iway/iwcm/Constants.java
@@ -1518,11 +1518,7 @@ public class Constants {
 				"Ak je true nebude elfinder ziskavat last modified, size a nebude sa kontrolovat, ci priecinky maju podpriecinky(bude sa predpokladat, ze ano)");
 
 		setString("contentSecurityPolicy", "", MOD_SECURITY,
-				"Obmedzenie ako stránka ma stranka nacitavat rôzne zdroje, ak mate httpS certifikat odporucame nastavit na hodnotu: default-src 'none'; script-src https: blob: data: 'unsafe-inline' 'unsafe-eval'; worker-src https: blob:; child-src https: blob:; style-src https: data: 'unsafe-inline' 'unsafe-eval'; img-src https: data: 'unsafe-inline'; font-src https: data:; object-src blob: 'self'; base-uri 'none'; frame-ancestors 'self'; connect-src blob: 'self'; frame-src 'self';"); // default-src
-																																																																																																																																																																		// https:
-																																																																																																																																																																		// data:
-																																																																																																																																																																		// 'unsafe-inline'
-																																																																																																																																																																		// 'unsafe-eval'
+				"Obmedzenie ako stránka ma stranka nacitavat rôzne zdroje, ak mate httpS certifikat odporucame nastavit na hodnotu: default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https: 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self'; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';");
 		setString("contentSecurityPolicySvg", "default-src 'self' 'unsafe-inline'", MOD_SECURITY,
 				"Obmedzenie pre SVG obrazky, ktore mozu obsahovat vlozeny javascript kod, odporucame nastavit na hodnotu: default-src 'self' 'unsafe-inline'");
 		setString("refererPolicy", "same-origin", MOD_SECURITY,

--- a/src/main/java/sk/iway/iwcm/Constants.java
+++ b/src/main/java/sk/iway/iwcm/Constants.java
@@ -1518,7 +1518,7 @@ public class Constants {
 				"Ak je true nebude elfinder ziskavat last modified, size a nebude sa kontrolovat, ci priecinky maju podpriecinky(bude sa predpokladat, ze ano)");
 
 		setString("contentSecurityPolicy", "", MOD_SECURITY,
-				"Obmedzenie ako stránka ma stranka nacitavat rôzne zdroje, ak mate httpS certifikat odporucame nastavit na hodnotu: default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https: 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self'; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; (Poznámka: {nonce} sa nahradí hodnotou 'nonce-<base64-value>' (vrátane úvodzoviek)");
+				"Obmedzenie ako stránka ma stranka nacitavat rôzne zdroje, ak mate httpS certifikat odporucame nastavit na hodnotu: default-src 'self'; script-src 'self' {nonce} https: 'strict-dynamic'; style-src 'self' https: {noAnce} 'unsafe-inline'; img-src 'self' https: data:; font-src 'self' https: data:; connect-src 'self' https:; frame-src 'self' www.youtube.com docs.google.com; media-src https:; object-src 'none'; frame-ancestors 'self'; base-uri 'self'; form-action 'self';");
 		setString("contentSecurityPolicySvg", "default-src 'self' 'unsafe-inline'", MOD_SECURITY,
 				"Obmedzenie pre SVG obrazky, ktore mozu obsahovat vlozeny javascript kod, odporucame nastavit na hodnotu: default-src 'self' 'unsafe-inline'");
 		setString("refererPolicy", "same-origin", MOD_SECURITY,

--- a/src/main/java/sk/iway/iwcm/PathFilter.java
+++ b/src/main/java/sk/iway/iwcm/PathFilter.java
@@ -2419,6 +2419,12 @@ public class PathFilter implements Filter
 		value = Tools.replace(value, "\r", " ");
 		value = Tools.replace(value, "\n", " ");
 
+		// Replace {nonce} placeholder with actual nonce from current request
+		RequestBean currentRequestBean = SetCharacterEncodingFilter.getCurrentRequestBean();
+		if (currentRequestBean != null && Tools.isNotEmpty(currentRequestBean.getCspNonce())) {
+			value = Tools.replace(value, "{nonce}", currentRequestBean.getCspNonce());
+		}
+
 		response.setHeader(headerName, value);
 	}
 

--- a/src/main/java/sk/iway/iwcm/PathFilter.java
+++ b/src/main/java/sk/iway/iwcm/PathFilter.java
@@ -2419,10 +2419,12 @@ public class PathFilter implements Filter
 		value = Tools.replace(value, "\r", " ");
 		value = Tools.replace(value, "\n", " ");
 
-		// Replace {nonce} placeholder with CSP nonce source expression ('nonce-<value>')
-		RequestBean currentRequestBean = SetCharacterEncodingFilter.getCurrentRequestBean();
-		if (currentRequestBean != null && Tools.isNotEmpty(currentRequestBean.getCspNonce())) {
-			value = Tools.replace(value, "{nonce}", "'nonce-" + currentRequestBean.getCspNonce() + "'");
+		if (value.contains("{nonce}")) {
+			// Replace {nonce} placeholder with CSP nonce source expression ('nonce-<value>')
+			RequestBean currentRequestBean = SetCharacterEncodingFilter.getCurrentRequestBean();
+			if (currentRequestBean != null && Tools.isNotEmpty(currentRequestBean.getCspNonce())) {
+				value = Tools.replace(value, "{nonce}", "'nonce-" + currentRequestBean.getCspNonce() + "'");
+			}
 		}
 
 		response.setHeader(headerName, value);

--- a/src/main/java/sk/iway/iwcm/PathFilter.java
+++ b/src/main/java/sk/iway/iwcm/PathFilter.java
@@ -2422,9 +2422,11 @@ public class PathFilter implements Filter
 		if (value.contains("{nonce}")) {
 			// Replace {nonce} placeholder with CSP nonce source expression ('nonce-<value>')
 			RequestBean currentRequestBean = SetCharacterEncodingFilter.getCurrentRequestBean();
+			String nonceValue = "";
 			if (currentRequestBean != null && Tools.isNotEmpty(currentRequestBean.getCspNonce())) {
-				value = Tools.replace(value, "{nonce}", "'nonce-" + currentRequestBean.getCspNonce() + "'");
+				nonceValue = currentRequestBean.getCspNonce();
 			}
+			value = Tools.replace(value, "{nonce}", "'nonce-" + nonceValue + "'");
 		}
 
 		response.setHeader(headerName, value);
@@ -2704,7 +2706,7 @@ public class PathFilter implements Filter
 	}
 
 	private static boolean isPathSafe(String path) {
-		if (path == null || path.length() < 1) return true;
+		if (path == null || path.isEmpty()) return true;
 
 		if (path.indexOf('\'')!=-1 || path.indexOf('"')!=-1 || path.indexOf('\r')!=-1 || path.indexOf('\n')!=-1 ||
 			path.contains("%0D") || path.contains("%0A") || path.contains("%0d") || path.contains("%0a") || //crlf utok

--- a/src/main/java/sk/iway/iwcm/PathFilter.java
+++ b/src/main/java/sk/iway/iwcm/PathFilter.java
@@ -2419,10 +2419,10 @@ public class PathFilter implements Filter
 		value = Tools.replace(value, "\r", " ");
 		value = Tools.replace(value, "\n", " ");
 
-		// Replace {nonce} placeholder with actual nonce from current request
+		// Replace {nonce} placeholder with CSP nonce source expression ('nonce-<value>')
 		RequestBean currentRequestBean = SetCharacterEncodingFilter.getCurrentRequestBean();
 		if (currentRequestBean != null && Tools.isNotEmpty(currentRequestBean.getCspNonce())) {
-			value = Tools.replace(value, "{nonce}", currentRequestBean.getCspNonce());
+			value = Tools.replace(value, "{nonce}", "'nonce-" + currentRequestBean.getCspNonce() + "'");
 		}
 
 		response.setHeader(headerName, value);

--- a/src/main/java/sk/iway/iwcm/RequestBean.java
+++ b/src/main/java/sk/iway/iwcm/RequestBean.java
@@ -59,6 +59,17 @@ public class RequestBean
 
 	private ApplicationContext springContext;
 
+	// CSP nonce for Content-Security-Policy header (generated per-request)
+	private String cspNonce;
+
+	public String getCspNonce() {
+		return cspNonce;
+	}
+
+	public void setCspNonce(String cspNonce) {
+		this.cspNonce = cspNonce;
+	}
+
 	//umoznuje prenasat atributy podobne ako request.set/getAttribute
 	private Map<String, Object> attributes;
 

--- a/src/main/java/sk/iway/iwcm/RequestBean.java
+++ b/src/main/java/sk/iway/iwcm/RequestBean.java
@@ -62,14 +62,6 @@ public class RequestBean
 	// CSP nonce for Content-Security-Policy header (generated per-request)
 	private String cspNonce;
 
-	public String getCspNonce() {
-		return cspNonce;
-	}
-
-	public void setCspNonce(String cspNonce) {
-		this.cspNonce = cspNonce;
-	}
-
 	//umoznuje prenasat atributy podobne ako request.set/getAttribute
 	private Map<String, Object> attributes;
 
@@ -500,5 +492,11 @@ public class RequestBean
 	}
 	public void setLngCookie(String lngCookie) {
 		this.lngCookie = lngCookie;
+	}
+	public String getCspNonce() {
+		return cspNonce;
+	}
+	public void setCspNonce(String cspNonce) {
+		this.cspNonce = cspNonce;
 	}
 }

--- a/src/main/java/sk/iway/iwcm/SetCharacterEncodingFilter.java
+++ b/src/main/java/sk/iway/iwcm/SetCharacterEncodingFilter.java
@@ -196,6 +196,30 @@ public class SetCharacterEncodingFilter extends OncePerRequestFilter
 		}
 
 		requests.put(Thread.currentThread().getId(), requestBean);
+		// Generate CSP nonce for this request
+		requestBean.setCspNonce(generateCspNonce());
+   }
+
+	/**
+	 * Generate a cryptographically secure random nonce for Content-Security-Policy.
+	 * Only generates nonce if contentSecurityPolicy configuration contains {nonce} placeholder.
+	 * Returns base64-encoded random bytes (standard CSP nonce format).
+	 * @return base64-encoded nonce string, or null if no {nonce} placeholder found
+	 */
+	private static String generateCspNonce() {
+		String cspValue = Constants.getString("contentSecurityPolicy");
+		if (Tools.isEmpty(cspValue) || !cspValue.contains("{nonce}")) {
+			return null;
+		}
+		try {
+			java.security.SecureRandom random = new java.security.SecureRandom();
+			byte[] bytes = new byte[16];
+			random.nextBytes(bytes);
+			return java.util.Base64.getEncoder().withoutPadding().encodeToString(bytes);
+		} catch (Exception e) {
+			Logger.error(SetCharacterEncodingFilter.class, "Failed to generate CSP nonce", e);
+			return null;
+		}
    }
 
    /**

--- a/src/main/java/sk/iway/iwcm/SetCharacterEncodingFilter.java
+++ b/src/main/java/sk/iway/iwcm/SetCharacterEncodingFilter.java
@@ -623,7 +623,7 @@ public class SetCharacterEncodingFilter extends OncePerRequestFilter
 			}
 		}
 
-   	PathFilter.setHeader(res, "X-Frame-Options", "xFrameOptions");
+   		PathFilter.setHeader(res, "X-Frame-Options", "xFrameOptions");
 		PathFilter.setAccessControlAllowOrigin(path, res);
 		PathFilter.setHeader(res, "X-XSS-Protection", "xXssProtection");
 		PathFilter.setHeader(res, "Server", "serverName");
@@ -636,7 +636,11 @@ public class SetCharacterEncodingFilter extends OncePerRequestFilter
 			//pre SVG mame separe CSP hlavicky
 			PathFilter.setHeader(res, "Content-Security-Policy", "contentSecurityPolicySvg");
 		} else {
-			PathFilter.setHeader(res, "Content-Security-Policy", "contentSecurityPolicy");
+			String cspValue = Constants.getString("contentSecurityPolicy");
+			if (Tools.isNotEmpty(cspValue) && cspValue.contains("{nonce}")==false) {
+				//if CSP contains {nonce} placeholder, it will be set in ShowDoc.java after replacing {nonce} with actual value
+				PathFilter.setHeader(res, "Content-Security-Policy", "contentSecurityPolicy");
+			}
 		}
 		PathFilter.setHeader(res, "Referrer-Policy", "refererPolicy");
 

--- a/src/main/java/sk/iway/iwcm/SetCharacterEncodingFilter.java
+++ b/src/main/java/sk/iway/iwcm/SetCharacterEncodingFilter.java
@@ -77,6 +77,8 @@ public class SetCharacterEncodingFilter extends OncePerRequestFilter
 
    public static final String PDF_PRINT_PARAM = "_printAsPdf";
 
+   private static final java.security.SecureRandom SECURE_RANDOM = new java.security.SecureRandom();
+
    //customizovana error hlaska pri nedostupnosti DB spojenia pri starte servera
    private static Map<String, String> dbErrorMessageText = new Hashtable<>();
    static {
@@ -118,9 +120,8 @@ public class SetCharacterEncodingFilter extends OncePerRequestFilter
    public static void registerDataContext(ServletRequest req)
    {
    	//iba HttpServletRequest ma session
-		if (req instanceof HttpServletRequest)
+		if (req instanceof HttpServletRequest request)
 		{
-			HttpServletRequest request = (HttpServletRequest)req;
 			registerDataContext(request);
 		}
    }
@@ -212,9 +213,8 @@ public class SetCharacterEncodingFilter extends OncePerRequestFilter
 			return null;
 		}
 		try {
-			java.security.SecureRandom random = new java.security.SecureRandom();
 			byte[] bytes = new byte[16];
-			random.nextBytes(bytes);
+			SECURE_RANDOM.nextBytes(bytes);
 			return java.util.Base64.getEncoder().withoutPadding().encodeToString(bytes);
 		} catch (Exception e) {
 			Logger.error(SetCharacterEncodingFilter.class, "Failed to generate CSP nonce", e);
@@ -668,8 +668,7 @@ public class SetCharacterEncodingFilter extends OncePerRequestFilter
 	 */
    private void checkSessionSerializable(ServletRequest servletRequest) throws ObjectNotSerializableException
 	{
-		if (servletRequest instanceof HttpServletRequest) {
-		   HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+		if (servletRequest instanceof HttpServletRequest httpRequest) {
 		   HttpSession session = httpRequest.getSession(false);
 		   if (session != null) {
 		       boolean serializable = true;
@@ -682,7 +681,7 @@ public class SetCharacterEncodingFilter extends OncePerRequestFilter
 		                   attrName, Tools.sessionGetAttribute(session, attrName)
 		           );
 		           if (!attributeSerializable) {
-		               if (items.length() > 0) {
+		               if (items.isEmpty() == false) {
 		                   items.append(", ");
 		               }
 		               items.append(attrName);
@@ -926,7 +925,7 @@ public class SetCharacterEncodingFilter extends OncePerRequestFilter
 			String principalName = Tools.getUserPrincipal(req).getName();
 			//Logger.debug(getClass(), "Parsing login from user principal...["+principalName+"]");
 			String userNameFromPrincipal = principalName.substring( principalName.indexOf('\\') + 1 );
-			///userNameFromPrincipal = userNameFromPrincipal.substring(0, userNameFromPrincipal.length());
+			//userNameFromPrincipal = userNameFromPrincipal.substring(0, userNameFromPrincipal.length());
 			//Logger.debug(getClass(), "Parsed '"+userNameFromPrincipal+"'");
 			return userNameFromPrincipal;
 		}

--- a/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
+++ b/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
@@ -1721,7 +1721,7 @@ private static String combineCss(String cssStyle)
         // Single regex pattern to match all three tag types (script, style, link)
         // Uses alternation to match any of: <script..., <style..., <link...rel="stylesheet"...>
         java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
-            "(<script[^>]*?>)|(<style[^>]*?>)|(<link\\b[^>]*?rel\\s*=\\s*(?:\"stylesheet\"|'stylesheet'|stylesheet)[^>]*?>)",
+            "(<script[^>]*?>)|(<style[^>]*?>)|(<link\\b[^>]*?rel\\s*=\\s*(?:\"stylesheet\"|'stylesheet'|stylesheet)[^>]*?>)", //NOSONAR
             java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL
         );
         java.util.regex.Matcher matcher = pattern.matcher(htmlContent);

--- a/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
+++ b/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
@@ -1701,20 +1701,16 @@ private static String combineCss(String cssStyle)
     }
 
     /**
-     * Forward request to JSP/Thymeleaf template with body processing.
-    /**
-     * Inject CSP nonce into all <script> tags in HTML content.
-     * Handles various script tag forms: &lt;script&gt;, &lt;script defer&gt;, &lt;script type="..."&gt;, etc.
-     *
-     * @param htmlContent The HTML content to process
-     * @param nonce The CSP nonce value to inject
-    * @return HTML content with nonce injected into script tags
-     */
-    /**
      * Injects CSP nonce into <script>, <style>, and <link rel="stylesheet"> tags in a single pass.
      * Optimized for memory efficiency: uses single StringBuilder, processes all tag types in one pass.
+     *
+     * @param htmlContent The HTML content to process
+     * @param nonce The CSP nonce value
+     * @param injectIntoScripts Whether to inject nonce into <script> tags (false if script-src allows unsafe-inline)
+     * @param injectIntoStyles Whether to inject nonce into <style> and <link> tags (false if style-src allows unsafe-inline)
+     * @return HTML content with nonce injected into eligible tags
      */
-    private String injectCspNonceIntoTags(String htmlContent, String nonce) {
+    private String injectCspNonceIntoTags(String htmlContent, String nonce, boolean injectIntoScripts, boolean injectIntoStyles) {
         if (Tools.isEmpty(htmlContent) || Tools.isEmpty(nonce)) {
             return htmlContent;
         }
@@ -1736,8 +1732,8 @@ private static String combineCss(String cssStyle)
             // Append text before this match
             sb.append(htmlContent, lastEnd, matcher.start());
             String tagContent = matcher.group(0);
-            // Determine which tag type and inject nonce
-            String processedTag = processTagForNonce(tagContent, nonce, scriptPattern, stylePattern, linkPattern);
+            // Determine which tag type and inject nonce (skip if corresponding CSP directive allows unsafe-inline)
+            String processedTag = processTagForNonce(tagContent, nonce, scriptPattern, stylePattern, linkPattern, injectIntoScripts, injectIntoStyles);
             sb.append(processedTag);
             lastEnd = matcher.end();
         }
@@ -1748,9 +1744,20 @@ private static String combineCss(String cssStyle)
 
     /**
      * Processes a single tag (script, style, or link) to inject nonce if not already present.
+     * Skips injection for tag types whose corresponding CSP directive allows unsafe-inline.
+     *
+     * @param tagContent The matched tag string
+     * @param nonce The CSP nonce value
+     * @param scriptPattern Pre-compiled pattern for script tags
+     * @param stylePattern Pre-compiled pattern for style tags
+     * @param linkPattern Pre-compiled pattern for link tags
+     * @param injectIntoScripts Whether to inject nonce into script tags
+     * @param injectIntoStyles Whether to inject nonce into style/link tags
+     * @return Processed tag string
      */
     private String processTagForNonce(String tagContent, String nonce, java.util.regex.Pattern scriptPattern,
-                                      java.util.regex.Pattern stylePattern, java.util.regex.Pattern linkPattern) {
+                                      java.util.regex.Pattern stylePattern, java.util.regex.Pattern linkPattern,
+                                      boolean injectIntoScripts, boolean injectIntoStyles) {
         // Check if nonce attribute is already present (lookbehind ensures nonce is preceded by whitespace or letter, not - or ?)
         if (java.util.regex.Pattern.compile("(?<=[\\sa-z])nonce\\s*=").matcher(tagContent).find()) {
             return tagContent;
@@ -1771,6 +1778,13 @@ private static String combineCss(String cssStyle)
             return tagContent;
         }
         String tagName = tagContent.substring(0, nameEnd).toLowerCase();
+        // Skip nonce injection for tag types whose CSP directive allows unsafe-inline
+        if (tagName.equals("<script") && !injectIntoScripts) {
+            return tagContent;
+        }
+        if ((tagName.equals("<style") || tagName.equals("<link")) && !injectIntoStyles) {
+            return tagContent;
+        }
         java.util.regex.Pattern tagSpecificPattern;
         switch (tagName) {
             case "<script":
@@ -1873,11 +1887,22 @@ private static String combineCss(String cssStyle)
                 ? SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce()
                 : null;
         if (Tools.isNotEmpty(capturedContent) && Tools.isNotEmpty(cspNonce)) {
+            String contentSecurityPolicy = Constants.getString("contentSecurityPolicy");
             PathFilter.setHeader(response, "Content-Security-Policy", "contentSecurityPolicy");
-            capturedContent = injectCspNonceIntoTags(capturedContent, cspNonce);
+            // Check each directive separately to skip nonce injection only for tag types
+            // whose corresponding CSP directive already allows unsafe-inline
+            boolean scriptSrcAllowsUnsafeInline = isDirectiveAllowsUnsafeInline(contentSecurityPolicy, "script-src");
+            boolean styleSrcAllowsUnsafeInline = isDirectiveAllowsUnsafeInline(contentSecurityPolicy, "style-src");
+            // Inject nonce into tags, skipping tag types whose directive allows unsafe-inline
+            capturedContent = injectCspNonceIntoTags(capturedContent, cspNonce, !scriptSrcAllowsUnsafeInline, !styleSrcAllowsUnsafeInline);
             // Process inline styles and event handlers for CSP compliance
-            capturedContent = processInlineStyles(capturedContent, cspNonce);
-            capturedContent = processInlineEventHandlers(capturedContent, cspNonce);
+            // Only process if unsafe-inline is NOT allowed (since browser already allows them)
+            if (scriptSrcAllowsUnsafeInline == false) {
+                capturedContent = processInlineEventHandlers(capturedContent, cspNonce);
+            }
+            if (styleSrcAllowsUnsafeInline == false) {
+                capturedContent = processInlineStyles(capturedContent, cspNonce);
+            }
         }
 
         if (capturedContent != null) {
@@ -2053,5 +2078,36 @@ private static String combineCss(String cssStyle)
         }
 
         return processedHtml.toString();
+    }
+
+    /**
+     * Checks if a specific CSP directive allows 'unsafe-inline'.
+     * Parses using indexOf to find the directive start and end (next ';' or end of string),
+     * then checks if 'unsafe-inline' exists within that range.
+     *
+     * @param cspValue The full CSP configuration string
+     * @param directiveName The directive name to check (e.g., "script-src", "style-src")
+     * @return true if the directive allows 'unsafe-inline'
+     */
+    private static boolean isDirectiveAllowsUnsafeInline(String cspValue, String directiveName) {
+        // Find the directive by looking for the name followed by whitespace
+        int directiveIndex = cspValue.indexOf(directiveName);
+        if (directiveIndex < 0) {
+            return false;
+        }
+        // Move past the directive name to the value part
+        int valueStart = directiveIndex + directiveName.length();
+        // Skip whitespace after directive name
+        while (valueStart < cspValue.length() && Character.isWhitespace(cspValue.charAt(valueStart))) {
+            valueStart++;
+        }
+        // Find the end of this directive (next ';' or end of string)
+        int directiveEnd = cspValue.indexOf(';', valueStart);
+        if (directiveEnd < 0) {
+            directiveEnd = cspValue.length();
+        }
+        // Check if 'unsafe-inline' appears within this directive's value
+        String directiveValue = cspValue.substring(valueStart, directiveEnd);
+        return directiveValue.indexOf("unsafe-inline") >= 0;
     }
 }

--- a/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
+++ b/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
@@ -1708,37 +1708,33 @@ private static String combineCss(String cssStyle)
      *
      * @param htmlContent The HTML content to process
      * @param nonce The CSP nonce value to inject
-     * @return HTML content with nonce injected into script tags
+    * @return HTML content with nonce injected into script tags
      */
     private String injectCspNonceIntoScripts(String htmlContent, String nonce) {
         if (Tools.isEmpty(htmlContent) || Tools.isEmpty(nonce)) {
             return htmlContent;
         }
-        // Match <script> tags (with optional attributes) and inject nonce attribute
+        // Match only opening <script> tags (not closing </script>), with optional attributes
         // Handles: <script>, <script defer>, <script type="...">, etc.
-        // Does NOT match <script nonce="..."> (already has nonce)
-        String pattern = "(<script(?:\\s+[^>]*?(?<!nonce\\s*=[\"']))?\\s*)>";
-        java.util.regex.Pattern patternObj = java.util.regex.Pattern.compile(pattern, java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL);
-        java.util.regex.Matcher matcher = patternObj.matcher(htmlContent);
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("(<script[^>]*?)>", java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL);
+        java.util.regex.Matcher matcher = pattern.matcher(htmlContent);
         StringBuffer sb = new StringBuffer();
+        java.util.regex.Pattern scriptPattern = java.util.regex.Pattern.compile("(<script)(\\s+[^>]*)?");
         while (matcher.find()) {
-            String tagStart = matcher.group(1);
+            String tagContent = matcher.group(1);
             // Check if nonce is already present
-            if (tagStart.toLowerCase().contains("nonce=")) {
+            if (tagContent.toLowerCase().contains("nonce=")) {
                 matcher.appendReplacement(sb, matcher.group(0));
             } else {
                 // Inject nonce attribute after existing attributes (or after "script")
-                String injectPoint = tagStart;
-                // Find the position to inject nonce - after any existing attributes
-                java.util.regex.Pattern scriptPattern = java.util.regex.Pattern.compile("(</?script)(\\s+[^>]*)?");
-                java.util.regex.Matcher scriptMatcher = scriptPattern.matcher(tagStart);
+                java.util.regex.Matcher scriptMatcher = scriptPattern.matcher(tagContent);
+                String injectPoint = tagContent;
                 if (scriptMatcher.find()) {
-                    String tagName = scriptMatcher.group(1);
                     String attributes = scriptMatcher.group(2);
                     if (Tools.isNotEmpty(attributes)) {
-                        injectPoint = tagName + attributes + " nonce=\"" + nonce + "\"";
+                        injectPoint = "<script" + attributes + " nonce=\"" + nonce + "\"";
                     } else {
-                        injectPoint = tagName + " nonce=\"" + nonce + "\"";
+                        injectPoint = "<script nonce=\"" + nonce + "\"";
                     }
                 }
                 matcher.appendReplacement(sb, injectPoint + ">");

--- a/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
+++ b/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
@@ -1710,114 +1710,93 @@ private static String combineCss(String cssStyle)
      * @param nonce The CSP nonce value to inject
     * @return HTML content with nonce injected into script tags
      */
+    /**
+     * Injects CSP nonce into <script>, <style>, and <link rel="stylesheet"> tags in a single pass.
+     * Optimized for memory efficiency: uses single StringBuilder, processes all tag types in one pass.
+     */
     private String injectCspNonceIntoTags(String htmlContent, String nonce) {
         if (Tools.isEmpty(htmlContent) || Tools.isEmpty(nonce)) {
             return htmlContent;
         }
-        String result = injectNonceIntoScriptTags(htmlContent, nonce);
-        result = injectNonceIntoStyleTags(result, nonce);
-        result = injectNonceIntoLinkTags(result, nonce);
-        return result;
-    }
-
-    /**
-     * Injects CSP nonce into <script> tags.
-     */
-    private String injectNonceIntoScriptTags(String htmlContent, String nonce) {
-        // Match only opening <script> tags (not closing </script>), with optional attributes
-        // Handles: <script>, <script defer>, <script type="...">, etc.
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("(<script[^>]*?)>", java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL);
+        // Single regex pattern to match all three tag types (script, style, link)
+        // Uses alternation to match any of: <script..., <style..., <link...rel="stylesheet"...>
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
+            "(<script[^>]*?>)|(<style[^>]*?>)|(<link\\b[^>]*?rel\\s*=\\s*(?:\"stylesheet\"|'stylesheet'|stylesheet)[^>]*?>)",
+            java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL
+        );
         java.util.regex.Matcher matcher = pattern.matcher(htmlContent);
-        StringBuffer sb = new StringBuffer();
+        // Use StringBuilder (no synchronization overhead) with initial capacity
+        StringBuilder sb = new StringBuilder(htmlContent.length());
+        // Pre-compile patterns for each tag type
         java.util.regex.Pattern scriptPattern = java.util.regex.Pattern.compile("(<script)(\\s+[^>]*)?");
-        while (matcher.find()) {
-            String tagContent = matcher.group(1);
-            // Check if nonce is already present
-            if (tagContent.toLowerCase().contains("nonce=")) {
-                matcher.appendReplacement(sb, matcher.group(0));
-            } else {
-                // Inject nonce attribute after existing attributes (or after "script")
-                java.util.regex.Matcher scriptMatcher = scriptPattern.matcher(tagContent);
-                String injectPoint = tagContent;
-                if (scriptMatcher.find()) {
-                    String attributes = scriptMatcher.group(2);
-                    if (Tools.isNotEmpty(attributes)) {
-                        injectPoint = "<script" + attributes + " nonce=\"" + nonce + "\"";
-                    } else {
-                        injectPoint = "<script nonce=\"" + nonce + "\"";
-                    }
-                }
-                matcher.appendReplacement(sb, injectPoint + ">");
-            }
-        }
-        matcher.appendTail(sb);
-        return sb.toString();
-    }
-
-    /**
-     * Injects CSP nonce into <style> tags.
-     */
-    private String injectNonceIntoStyleTags(String htmlContent, String nonce) {
-        // Match only opening <style> tags (not closing </style>), with optional attributes
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("(<style[^>]*?)>", java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL);
-        java.util.regex.Matcher matcher = pattern.matcher(htmlContent);
-        StringBuffer sb = new StringBuffer();
         java.util.regex.Pattern stylePattern = java.util.regex.Pattern.compile("(<style)(\\s+[^>]*)?");
+        java.util.regex.Pattern linkPattern = java.util.regex.Pattern.compile("(<link)(\\s+[^>]*)?");
+        int lastEnd = 0;
         while (matcher.find()) {
-            String tagContent = matcher.group(1);
-            // Check if nonce is already present
-            if (tagContent.toLowerCase().contains("nonce=")) {
-                matcher.appendReplacement(sb, matcher.group(0));
-            } else {
-                // Inject nonce attribute after existing attributes (or after "style")
-                java.util.regex.Matcher styleMatcher = stylePattern.matcher(tagContent);
-                String injectPoint = tagContent;
-                if (styleMatcher.find()) {
-                    String attributes = styleMatcher.group(2);
-                    if (Tools.isNotEmpty(attributes)) {
-                        injectPoint = "<style" + attributes + " nonce=\"" + nonce + "\"";
-                    } else {
-                        injectPoint = "<style nonce=\"" + nonce + "\"";
-                    }
-                }
-                matcher.appendReplacement(sb, injectPoint + ">");
-            }
+            // Append text before this match
+            sb.append(htmlContent, lastEnd, matcher.start());
+            String tagContent = matcher.group(0);
+            // Determine which tag type and inject nonce
+            String processedTag = processTagForNonce(tagContent, nonce, scriptPattern, stylePattern, linkPattern);
+            sb.append(processedTag);
+            lastEnd = matcher.end();
         }
-        matcher.appendTail(sb);
+        // Append remaining text after last match
+        sb.append(htmlContent, lastEnd, htmlContent.length());
         return sb.toString();
     }
 
     /**
-     * Injects CSP nonce into <link rel="stylesheet"> tags.
+     * Processes a single tag (script, style, or link) to inject nonce if not already present.
      */
-    private String injectNonceIntoLinkTags(String htmlContent, String nonce) {
-        // Match <link> tags with rel="stylesheet" (case-insensitive), handling single/double/no quotes
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("(<link\\b[^>]*?rel\\s*=\\s*(?:\"stylesheet\"|'stylesheet'|stylesheet)[^>]*?)>", java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL);
-        java.util.regex.Matcher matcher = pattern.matcher(htmlContent);
-        StringBuffer sb = new StringBuffer();
-        java.util.regex.Pattern linkPattern = java.util.regex.Pattern.compile("(<link)(\\s+[^>]*)?");
-        while (matcher.find()) {
-            String tagContent = matcher.group(1);
-            // Check if nonce is already present
-            if (tagContent.toLowerCase().contains("nonce=")) {
-                matcher.appendReplacement(sb, matcher.group(0));
+    private String processTagForNonce(String tagContent, String nonce, java.util.regex.Pattern scriptPattern,
+                                      java.util.regex.Pattern stylePattern, java.util.regex.Pattern linkPattern) {
+        // Check if nonce is already present
+        if (tagContent.toLowerCase().contains("nonce=")) {
+            return tagContent;
+        }
+        // Extract tag name (handles both <script> and <script type="...">)
+        // Find the end of the tag name (space or '>')
+        int gtIndex = tagContent.indexOf('>');
+        int spaceIndex = tagContent.indexOf(' ');
+        int nameEnd;
+        if (spaceIndex < 0) {
+            nameEnd = gtIndex;
+        } else if (gtIndex < 0) {
+            nameEnd = spaceIndex;
+        } else {
+            nameEnd = Math.min(spaceIndex, gtIndex);
+        }
+        if (nameEnd < 0) {
+            return tagContent;
+        }
+        String tagName = tagContent.substring(0, nameEnd).toLowerCase();
+        java.util.regex.Pattern tagSpecificPattern;
+        switch (tagName) {
+            case "<script":
+                tagSpecificPattern = scriptPattern;
+                break;
+            case "<style":
+                tagSpecificPattern = stylePattern;
+                break;
+            case "<link":
+                tagSpecificPattern = linkPattern;
+                break;
+            default:
+                return tagContent;
+        }
+        // Inject nonce attribute after existing attributes (or after tag name)
+        java.util.regex.Matcher tagMatcher = tagSpecificPattern.matcher(tagContent);
+        String injectPoint = tagContent;
+        if (tagMatcher.find()) {
+            String attributes = tagMatcher.group(2);
+            if (Tools.isNotEmpty(attributes)) {
+                injectPoint = tagName + attributes + " nonce=\"" + nonce + "\"";
             } else {
-                // Inject nonce attribute after existing attributes (or after "link")
-                java.util.regex.Matcher linkMatcher = linkPattern.matcher(tagContent);
-                String injectPoint = tagContent;
-                if (linkMatcher.find()) {
-                    String attributes = linkMatcher.group(2);
-                    if (Tools.isNotEmpty(attributes)) {
-                        injectPoint = "<link" + attributes + " nonce=\"" + nonce + "\"";
-                    } else {
-                        injectPoint = "<link nonce=\"" + nonce + "\"";
-                    }
-                }
-                matcher.appendReplacement(sb, injectPoint + ">");
+                injectPoint = tagName + " nonce=\"" + nonce + "\"";
             }
         }
-        matcher.appendTail(sb);
-        return sb.toString();
+        return injectPoint + ">";
     }
 
     /**

--- a/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
+++ b/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
@@ -1717,11 +1717,12 @@ private static String combineCss(String cssStyle)
 
         // Check if body processing is needed (either style-to-head or CSP nonce injection)
         boolean needsStyleProcessing = StyleToHeadHelper.isMoveStyleToHeadEnabled(request);
-        boolean needsCspNonce = SetCharacterEncodingFilter.getCurrentRequestBean() != null
-                && Tools.isNotEmpty(SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce());
-        boolean needsProcessing = needsStyleProcessing || needsCspNonce;
+        String cspNonce = SetCharacterEncodingFilter.getCurrentRequestBean() != null
+                ? SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce()
+                : null;
+        boolean needsProcessing = needsStyleProcessing || Tools.isNotEmpty(cspNonce);
 
-        if (!needsProcessing) {
+        if (needsProcessing == false) {
             // No body processing needed, use standard forward
             request.getRequestDispatcher(forward).forward(request, response);
             return;
@@ -1771,9 +1772,6 @@ private static String combineCss(String cssStyle)
         }
 
         // Inject CSP nonce into <script>, <style>, and <link> tags
-        String cspNonce = SetCharacterEncodingFilter.getCurrentRequestBean() != null
-                ? SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce()
-                : null;
         if (Tools.isNotEmpty(capturedContent) && Tools.isNotEmpty(cspNonce)) {
             String contentSecurityPolicy = Constants.getString("contentSecurityPolicy");
             PathFilter.setHeader(response, "Content-Security-Policy", "contentSecurityPolicy");

--- a/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
+++ b/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
@@ -1727,10 +1727,10 @@ private static String combineCss(String cssStyle)
         java.util.regex.Matcher matcher = pattern.matcher(htmlContent);
         // Use StringBuilder (no synchronization overhead) with initial capacity
         StringBuilder sb = new StringBuilder(htmlContent.length());
-        // Pre-compile patterns for each tag type
-        java.util.regex.Pattern scriptPattern = java.util.regex.Pattern.compile("(<script)(\\s+[^>]*)?");
-        java.util.regex.Pattern stylePattern = java.util.regex.Pattern.compile("(<style)(\\s+[^>]*)?");
-        java.util.regex.Pattern linkPattern = java.util.regex.Pattern.compile("(<link)(\\s+[^>]*)?");
+        // Pre-compile patterns for each tag type (includes closing '>' to handle plain tags like <style>)
+        java.util.regex.Pattern scriptPattern = java.util.regex.Pattern.compile("(<script)(\\s+[^>]*)?>");
+        java.util.regex.Pattern stylePattern = java.util.regex.Pattern.compile("(<style)(\\s+[^>]*)?>");
+        java.util.regex.Pattern linkPattern = java.util.regex.Pattern.compile("(<link)(\\s+[^>]*)?>");
         int lastEnd = 0;
         while (matcher.find()) {
             // Append text before this match
@@ -1858,14 +1858,6 @@ private static String combineCss(String cssStyle)
         // Get the captured content
         String capturedContent = responseWrapper.getCapturedContent();
 
-        // Inject CSP nonce into <script>, <style>, and <link> tags
-        String cspNonce = SetCharacterEncodingFilter.getCurrentRequestBean() != null
-                ? SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce()
-                : null;
-        if (Tools.isNotEmpty(capturedContent) && Tools.isNotEmpty(cspNonce)) {
-            capturedContent = injectCspNonceIntoTags(capturedContent, cspNonce);
-        }
-
         // Check if we have collected styles to insert
         if (needsStyleProcessing && StyleToHeadHelper.hasCollectedStyles(request) && Tools.isNotEmpty(capturedContent)) {
             // Insert styles into head section
@@ -1874,6 +1866,15 @@ private static String combineCss(String cssStyle)
 
             // Write processed content to original response
             capturedContent = processedHtml;
+        }
+
+        // Inject CSP nonce into <script>, <style>, and <link> tags
+        String cspNonce = SetCharacterEncodingFilter.getCurrentRequestBean() != null
+                ? SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce()
+                : null;
+        if (Tools.isNotEmpty(capturedContent) && Tools.isNotEmpty(cspNonce)) {
+            PathFilter.setHeader(response, "Content-Security-Policy", "contentSecurityPolicy");
+            capturedContent = injectCspNonceIntoTags(capturedContent, cspNonce);
         }
 
         if (capturedContent != null) {

--- a/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
+++ b/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
@@ -1702,6 +1702,54 @@ private static String combineCss(String cssStyle)
 
     /**
      * Forward request to JSP/Thymeleaf template with body processing.
+    /**
+     * Inject CSP nonce into all <script> tags in HTML content.
+     * Handles various script tag forms: &lt;script&gt;, &lt;script defer&gt;, &lt;script type="..."&gt;, etc.
+     *
+     * @param htmlContent The HTML content to process
+     * @param nonce The CSP nonce value to inject
+     * @return HTML content with nonce injected into script tags
+     */
+    private String injectCspNonceIntoScripts(String htmlContent, String nonce) {
+        if (Tools.isEmpty(htmlContent) || Tools.isEmpty(nonce)) {
+            return htmlContent;
+        }
+        // Match <script> tags (with optional attributes) and inject nonce attribute
+        // Handles: <script>, <script defer>, <script type="...">, etc.
+        // Does NOT match <script nonce="..."> (already has nonce)
+        String pattern = "(<script(?:\\s+[^>]*?(?<!nonce\\s*=[\"']))?\\s*)>";
+        java.util.regex.Pattern patternObj = java.util.regex.Pattern.compile(pattern, java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL);
+        java.util.regex.Matcher matcher = patternObj.matcher(htmlContent);
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            String tagStart = matcher.group(1);
+            // Check if nonce is already present
+            if (tagStart.toLowerCase().contains("nonce=")) {
+                matcher.appendReplacement(sb, matcher.group(0));
+            } else {
+                // Inject nonce attribute after existing attributes (or after "script")
+                String injectPoint = tagStart;
+                // Find the position to inject nonce - after any existing attributes
+                java.util.regex.Pattern scriptPattern = java.util.regex.Pattern.compile("(</?script)(\\s+[^>]*)?");
+                java.util.regex.Matcher scriptMatcher = scriptPattern.matcher(tagStart);
+                if (scriptMatcher.find()) {
+                    String tagName = scriptMatcher.group(1);
+                    String attributes = scriptMatcher.group(2);
+                    if (Tools.isNotEmpty(attributes)) {
+                        injectPoint = tagName + attributes + " nonce=\"" + nonce + "\"";
+                    } else {
+                        injectPoint = tagName + " nonce=\"" + nonce + "\"";
+                    }
+                }
+                matcher.appendReplacement(sb, injectPoint + ">");
+            }
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    /**
+     * Forwards to a template and optionally processes the response body.
      * If showDocMoveStyleToHead is enabled, captures the response, extracts collected styles
      * from components, and inserts them into the head section.
      *
@@ -1752,6 +1800,14 @@ private static String combineCss(String cssStyle)
 
         // Get the captured content
         String capturedContent = responseWrapper.getCapturedContent();
+
+        // Inject CSP nonce into <script> tags
+        String cspNonce = SetCharacterEncodingFilter.getCurrentRequestBean() != null
+                ? SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce()
+                : null;
+        if (Tools.isNotEmpty(capturedContent) && Tools.isNotEmpty(cspNonce)) {
+            capturedContent = injectCspNonceIntoScripts(capturedContent, cspNonce);
+        }
 
         // Check if we have collected styles to insert
         if (StyleToHeadHelper.hasCollectedStyles(request) && Tools.isNotEmpty(capturedContent)) {

--- a/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
+++ b/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
@@ -1875,6 +1875,9 @@ private static String combineCss(String cssStyle)
         if (Tools.isNotEmpty(capturedContent) && Tools.isNotEmpty(cspNonce)) {
             PathFilter.setHeader(response, "Content-Security-Policy", "contentSecurityPolicy");
             capturedContent = injectCspNonceIntoTags(capturedContent, cspNonce);
+            // Process inline styles and event handlers for CSP compliance
+            capturedContent = processInlineStyles(capturedContent, cspNonce);
+            capturedContent = processInlineEventHandlers(capturedContent, cspNonce);
         }
 
         if (capturedContent != null) {
@@ -1885,5 +1888,170 @@ private static String combineCss(String cssStyle)
 
         // Clear collected styles
         StyleToHeadHelper.clearCollectedStyles(request);
+    }
+
+    /**
+     * Processes inline styles by replacing them with data attributes and injecting CSS rules with nonce.
+     * For elements with inline style="...", replaces with data-inline-style="counter" and generates
+     * CSS rules like [data-inline-style="1"] { property: value !important; }.
+     *
+     * @param htmlContent The HTML content
+     * @param nonce The CSP nonce
+     * @return Processed HTML with inline styles replaced and CSS injected
+     */
+    private String processInlineStyles(String htmlContent, String nonce) {
+        if (Tools.isEmpty(htmlContent) || Tools.isEmpty(nonce)) {
+            return htmlContent;
+        }
+
+        // Find all elements with inline style attributes (handles both double and single quotes)
+        java.util.regex.Pattern stylePattern = java.util.regex.Pattern.compile(
+            "(\\s+style\\s*=\\s*)(\"([^\"]*)\")|(\\s+style\\s*=\\s*)('([^']*)')",
+            java.util.regex.Pattern.CASE_INSENSITIVE
+        );
+        java.util.regex.Matcher matcher = stylePattern.matcher(htmlContent);
+
+        StringBuilder cssRules = new StringBuilder();
+        int styleCounter = 0;
+        StringBuilder processedHtml = new StringBuilder(htmlContent.length());
+        int lastEnd = 0;
+
+        while (matcher.find()) {
+            styleCounter++;
+            String quotePrefix;
+            String styleValue;
+
+            // Determine which quote style was used (group 1 = double-quoted prefix, group 4 = single-quoted prefix)
+            if (matcher.group(1) != null) {
+                quotePrefix = matcher.group(1);
+                styleValue = matcher.group(3); // double-quoted value
+            } else {
+                quotePrefix = matcher.group(4);
+                styleValue = matcher.group(6); // single-quoted value
+            }
+
+            String dataAttr = quotePrefix.replace("style", "data-inline-style") + "\"nonce" + styleCounter + "\"";
+
+            // Append text before this match
+            processedHtml.append(htmlContent, lastEnd, matcher.start());
+            processedHtml.append(dataAttr);
+
+            // Generate CSS rule with !important for each property
+            cssRules.append("       [data-inline-style=\"nonce").append(styleCounter).append("\"] {");
+
+            // Parse CSS properties and add !important to each
+            String[] properties = styleValue.split(";");
+            for (String prop : properties) {
+                String trimmed = prop.trim();
+                if (Tools.isNotEmpty(trimmed) && trimmed.contains(":")) {
+                    // Remove trailing semicolon if present, then append " !important;"
+                    String propPart = trimmed.endsWith(";") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+                    cssRules.append(propPart).append(" !important;");
+                }
+            }
+            cssRules.append("}\n");
+
+            lastEnd = matcher.end();
+        }
+
+        // Append remaining text
+        processedHtml.append(htmlContent, lastEnd, htmlContent.length());
+
+        // If we found inline styles, inject CSS with nonce
+        if (styleCounter > 0) {
+            String styleInjection = "\n<style nonce=\"" + nonce + "\">\n" + cssRules.toString() + "</style>\n";
+            // Find the closing </body> tag and insert before it, or append at end
+            int bodyCloseIndex = processedHtml.lastIndexOf("</body>");
+            if (bodyCloseIndex > 0) {
+                processedHtml.insert(bodyCloseIndex, styleInjection);
+            } else {
+                processedHtml.append(styleInjection);
+            }
+        }
+
+        return processedHtml.toString();
+    }
+
+    /**
+     * Processes inline event handlers by replacing them with data attributes and injecting JavaScript with nonce.
+     * For elements with inline event handlers (onclick, onmouseover, etc.), replaces with
+     * data-inline-onclick="counter" and generates JavaScript code to restore the handlers.
+     *
+     * @param htmlContent The HTML content
+     * @param nonce The CSP nonce
+     * @return Processed HTML with inline event handlers replaced and JavaScript injected
+     */
+    private String processInlineEventHandlers(String htmlContent, String nonce) {
+        if (Tools.isEmpty(htmlContent) || Tools.isEmpty(nonce)) {
+            return htmlContent;
+        }
+
+        // Find all inline event handlers (onclick, onmouseover, onmouseout, onfocus, onblur, etc.)
+        // Handles both double and single quotes
+        java.util.regex.Pattern eventPattern = java.util.regex.Pattern.compile(
+            "(\\s+(onclick|onmouseover|onmouseout|onfocus|onblur|onkeydown|onkeyup|onsubmit|onchange|oninput|ondblclick|oncontextmenu|ondrag|ondrop)\\s*=\\s*)(\"([^\"]*)\")|(\\s+(onclick|onmouseover|onmouseout|onfocus|onblur|onkeydown|onkeyup|onsubmit|onchange|oninput|ondblclick|oncontextmenu|ondrop)\\s*=\\s*)('([^']*)')",
+            java.util.regex.Pattern.CASE_INSENSITIVE
+        );
+        java.util.regex.Matcher matcher = eventPattern.matcher(htmlContent);
+
+        StringBuilder jsCode = new StringBuilder();
+        java.util.Map<String, Integer> eventCounters = new java.util.HashMap<>();
+        StringBuilder processedHtml = new StringBuilder(htmlContent.length());
+        int lastEnd = 0;
+
+        while (matcher.find()) {
+            String quotePrefix;
+            String eventType;
+            String handlerValue;
+
+            // Determine which quote style was used
+            if (matcher.group(1) != null) {
+                quotePrefix = matcher.group(1);
+                eventType = matcher.group(2).toLowerCase();
+                handlerValue = matcher.group(4); // double-quoted
+            } else {
+                quotePrefix = matcher.group(5);
+                eventType = matcher.group(6).toLowerCase();
+                handlerValue = matcher.group(8); // single-quoted
+            }
+
+            //unfilter values
+            handlerValue = handlerValue.replace("&#39;", "'");
+            handlerValue = handlerValue.replace("&quot;", "\"");
+
+            // Get or create counter for this event type
+            int counter = eventCounters.getOrDefault(eventType, 0) + 1;
+            eventCounters.put(eventType, counter);
+
+            String dataAttr = quotePrefix.replace(eventType, "data-inline-" + eventType) + "\"nonce" + counter + "\"";
+
+            // Append text before this match
+            processedHtml.append(htmlContent, lastEnd, matcher.start());
+            processedHtml.append(dataAttr);
+
+            // Generate JavaScript to restore the event handler
+            jsCode.append("       document.querySelectorAll('[data-inline-").append(eventType).append("=\"nonce").append(counter).append("\"]').forEach(function(el) {");
+            jsCode.append("el.").append(eventType).append(" = function(event) {").append(handlerValue).append(";};");
+            jsCode.append("});\n");
+
+            lastEnd = matcher.end();
+        }
+
+        // Append remaining text
+        processedHtml.append(htmlContent, lastEnd, htmlContent.length());
+
+        // If we found inline event handlers, inject JavaScript with nonce
+        if (!eventCounters.isEmpty()) {
+            String scriptInjection = "\n<script nonce=\"" + nonce + "\">\n" + jsCode.toString() + "</script>\n";
+            // Find the closing </body> tag and insert before it, or append at end
+            int bodyCloseIndex = processedHtml.lastIndexOf("</body>");
+            if (bodyCloseIndex > 0) {
+                processedHtml.insert(bodyCloseIndex, scriptInjection);
+            } else {
+                processedHtml.append(scriptInjection);
+            }
+        }
+
+        return processedHtml.toString();
     }
 }

--- a/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
+++ b/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
@@ -1897,11 +1897,11 @@ private static String combineCss(String cssStyle)
             capturedContent = injectCspNonceIntoTags(capturedContent, cspNonce, !scriptSrcAllowsUnsafeInline, !styleSrcAllowsUnsafeInline);
             // Process inline styles and event handlers for CSP compliance
             // Only process if unsafe-inline is NOT allowed (since browser already allows them)
-            if (scriptSrcAllowsUnsafeInline == false) {
-                capturedContent = processInlineEventHandlers(capturedContent, cspNonce);
-            }
             if (styleSrcAllowsUnsafeInline == false) {
                 capturedContent = processInlineStyles(capturedContent, cspNonce);
+            }
+            if (scriptSrcAllowsUnsafeInline == false) {
+                capturedContent = processInlineEventHandlers(capturedContent, cspNonce);
             }
         }
 
@@ -2014,7 +2014,7 @@ private static String combineCss(String cssStyle)
         // Find all inline event handlers (onclick, onmouseover, onmouseout, onfocus, onblur, etc.)
         // Handles both double and single quotes
         java.util.regex.Pattern eventPattern = java.util.regex.Pattern.compile(
-            "(\\s+(onclick|onmouseover|onmouseout|onfocus|onblur|onkeydown|onkeyup|onsubmit|onchange|oninput|ondblclick|oncontextmenu|ondrag|ondrop)\\s*=\\s*)(\"([^\"]*)\")|(\\s+(onclick|onmouseover|onmouseout|onfocus|onblur|onkeydown|onkeyup|onsubmit|onchange|oninput|ondblclick|oncontextmenu|ondrop)\\s*=\\s*)('([^']*)')",
+            "(\\s+(onclick|onmouseover|onmouseout|onfocus|onblur|onkeydown|onkeyup|onsubmit|onchange|oninput|ondblclick|oncontextmenu|ondrag|ondrop)\\s*=\\s*)(\"([^\"]*)\")|(\\s+(onclick|onmouseover|onmouseout|onfocus|onblur|onkeydown|onkeyup|onsubmit|onchange|oninput|ondblclick|oncontextmenu|ondrop)\\s*=\\s*)('([^']*)')", //NOSONAR
             java.util.regex.Pattern.CASE_INSENSITIVE
         );
         java.util.regex.Matcher matcher = eventPattern.matcher(htmlContent);
@@ -2108,6 +2108,7 @@ private static String combineCss(String cssStyle)
         }
         // Check if 'unsafe-inline' appears within this directive's value
         String directiveValue = cspValue.substring(valueStart, directiveEnd);
-        return directiveValue.indexOf("unsafe-inline") >= 0;
+        if (directiveValue.contains("{nonce}")) return false;
+        return directiveValue.contains("unsafe-inline");
     }
 }

--- a/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
+++ b/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
@@ -1710,10 +1710,20 @@ private static String combineCss(String cssStyle)
      * @param nonce The CSP nonce value to inject
     * @return HTML content with nonce injected into script tags
      */
-    private String injectCspNonceIntoScripts(String htmlContent, String nonce) {
+    private String injectCspNonceIntoTags(String htmlContent, String nonce) {
         if (Tools.isEmpty(htmlContent) || Tools.isEmpty(nonce)) {
             return htmlContent;
         }
+        String result = injectNonceIntoScriptTags(htmlContent, nonce);
+        result = injectNonceIntoStyleTags(result, nonce);
+        result = injectNonceIntoLinkTags(result, nonce);
+        return result;
+    }
+
+    /**
+     * Injects CSP nonce into <script> tags.
+     */
+    private String injectNonceIntoScriptTags(String htmlContent, String nonce) {
         // Match only opening <script> tags (not closing </script>), with optional attributes
         // Handles: <script>, <script defer>, <script type="...">, etc.
         java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("(<script[^>]*?)>", java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL);
@@ -1735,6 +1745,72 @@ private static String combineCss(String cssStyle)
                         injectPoint = "<script" + attributes + " nonce=\"" + nonce + "\"";
                     } else {
                         injectPoint = "<script nonce=\"" + nonce + "\"";
+                    }
+                }
+                matcher.appendReplacement(sb, injectPoint + ">");
+            }
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    /**
+     * Injects CSP nonce into <style> tags.
+     */
+    private String injectNonceIntoStyleTags(String htmlContent, String nonce) {
+        // Match only opening <style> tags (not closing </style>), with optional attributes
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("(<style[^>]*?)>", java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL);
+        java.util.regex.Matcher matcher = pattern.matcher(htmlContent);
+        StringBuffer sb = new StringBuffer();
+        java.util.regex.Pattern stylePattern = java.util.regex.Pattern.compile("(<style)(\\s+[^>]*)?");
+        while (matcher.find()) {
+            String tagContent = matcher.group(1);
+            // Check if nonce is already present
+            if (tagContent.toLowerCase().contains("nonce=")) {
+                matcher.appendReplacement(sb, matcher.group(0));
+            } else {
+                // Inject nonce attribute after existing attributes (or after "style")
+                java.util.regex.Matcher styleMatcher = stylePattern.matcher(tagContent);
+                String injectPoint = tagContent;
+                if (styleMatcher.find()) {
+                    String attributes = styleMatcher.group(2);
+                    if (Tools.isNotEmpty(attributes)) {
+                        injectPoint = "<style" + attributes + " nonce=\"" + nonce + "\"";
+                    } else {
+                        injectPoint = "<style nonce=\"" + nonce + "\"";
+                    }
+                }
+                matcher.appendReplacement(sb, injectPoint + ">");
+            }
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    /**
+     * Injects CSP nonce into <link rel="stylesheet"> tags.
+     */
+    private String injectNonceIntoLinkTags(String htmlContent, String nonce) {
+        // Match <link> tags with rel="stylesheet" (case-insensitive), handling single/double/no quotes
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("(<link\\b[^>]*?rel\\s*=\\s*(?:\"stylesheet\"|'stylesheet'|stylesheet)[^>]*?)>", java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL);
+        java.util.regex.Matcher matcher = pattern.matcher(htmlContent);
+        StringBuffer sb = new StringBuffer();
+        java.util.regex.Pattern linkPattern = java.util.regex.Pattern.compile("(<link)(\\s+[^>]*)?");
+        while (matcher.find()) {
+            String tagContent = matcher.group(1);
+            // Check if nonce is already present
+            if (tagContent.toLowerCase().contains("nonce=")) {
+                matcher.appendReplacement(sb, matcher.group(0));
+            } else {
+                // Inject nonce attribute after existing attributes (or after "link")
+                java.util.regex.Matcher linkMatcher = linkPattern.matcher(tagContent);
+                String injectPoint = tagContent;
+                if (linkMatcher.find()) {
+                    String attributes = linkMatcher.group(2);
+                    if (Tools.isNotEmpty(attributes)) {
+                        injectPoint = "<link" + attributes + " nonce=\"" + nonce + "\"";
+                    } else {
+                        injectPoint = "<link nonce=\"" + nonce + "\"";
                     }
                 }
                 matcher.appendReplacement(sb, injectPoint + ">");
@@ -1802,7 +1878,7 @@ private static String combineCss(String cssStyle)
                 ? SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce()
                 : null;
         if (Tools.isNotEmpty(capturedContent) && Tools.isNotEmpty(cspNonce)) {
-            capturedContent = injectCspNonceIntoScripts(capturedContent, cspNonce);
+            capturedContent = injectCspNonceIntoTags(capturedContent, cspNonce);
         }
 
         // Check if we have collected styles to insert

--- a/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
+++ b/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
@@ -1751,8 +1751,8 @@ private static String combineCss(String cssStyle)
      */
     private String processTagForNonce(String tagContent, String nonce, java.util.regex.Pattern scriptPattern,
                                       java.util.regex.Pattern stylePattern, java.util.regex.Pattern linkPattern) {
-        // Check if nonce is already present
-        if (tagContent.toLowerCase().contains("nonce=")) {
+        // Check if nonce attribute is already present (lookbehind ensures nonce is preceded by whitespace or letter, not - or ?)
+        if (java.util.regex.Pattern.compile("(?<=[\\sa-z])nonce\\s*=").matcher(tagContent).find()) {
             return tagContent;
         }
         // Extract tag name (handles both <script> and <script type="...">)

--- a/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
+++ b/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
@@ -1813,8 +1813,14 @@ private static String combineCss(String cssStyle)
     private void forwardWithBodyProcessing(String forward, HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
 
-        if (StyleToHeadHelper.isMoveStyleToHeadEnabled(request)==false) {
-            // Feature disabled, use standard forward
+        // Check if body processing is needed (either style-to-head or CSP nonce injection)
+        boolean needsStyleProcessing = StyleToHeadHelper.isMoveStyleToHeadEnabled(request);
+        boolean needsCspNonce = SetCharacterEncodingFilter.getCurrentRequestBean() != null
+                && Tools.isNotEmpty(SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce());
+        boolean needsProcessing = needsStyleProcessing || needsCspNonce;
+
+        if (!needsProcessing) {
+            // No body processing needed, use standard forward
             request.getRequestDispatcher(forward).forward(request, response);
             return;
         }
@@ -1852,7 +1858,7 @@ private static String combineCss(String cssStyle)
         // Get the captured content
         String capturedContent = responseWrapper.getCapturedContent();
 
-        // Inject CSP nonce into <script> tags
+        // Inject CSP nonce into <script>, <style>, and <link> tags
         String cspNonce = SetCharacterEncodingFilter.getCurrentRequestBean() != null
                 ? SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce()
                 : null;
@@ -1861,7 +1867,7 @@ private static String combineCss(String cssStyle)
         }
 
         // Check if we have collected styles to insert
-        if (StyleToHeadHelper.hasCollectedStyles(request) && Tools.isNotEmpty(capturedContent)) {
+        if (needsStyleProcessing && StyleToHeadHelper.hasCollectedStyles(request) && Tools.isNotEmpty(capturedContent)) {
             // Insert styles into head section
             String styles = StyleToHeadHelper.getCollectedStyles(request);
             String processedHtml = StyleToHeadHelper.insertStylesIntoHead(capturedContent, styles);

--- a/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
+++ b/src/main/java/sk/iway/iwcm/doc/ShowDoc.java
@@ -41,6 +41,7 @@ import sk.iway.iwcm.components.response_header.rest.ResponseHeaderService;
 import sk.iway.iwcm.doc.ninja.Amp;
 import sk.iway.iwcm.doc.ninja.Ninja;
 import sk.iway.iwcm.doc.showdoc.ContentCapturingResponseWrapper;
+import sk.iway.iwcm.doc.showdoc.NonceHelper;
 import sk.iway.iwcm.doc.showdoc.StyleToHeadHelper;
 import sk.iway.iwcm.editor.service.WebpagesService;
 import sk.iway.iwcm.i18n.Prop;
@@ -1701,119 +1702,6 @@ private static String combineCss(String cssStyle)
     }
 
     /**
-     * Injects CSP nonce into <script>, <style>, and <link rel="stylesheet"> tags in a single pass.
-     * Optimized for memory efficiency: uses single StringBuilder, processes all tag types in one pass.
-     *
-     * @param htmlContent The HTML content to process
-     * @param nonce The CSP nonce value
-     * @param injectIntoScripts Whether to inject nonce into <script> tags (false if script-src allows unsafe-inline)
-     * @param injectIntoStyles Whether to inject nonce into <style> and <link> tags (false if style-src allows unsafe-inline)
-     * @return HTML content with nonce injected into eligible tags
-     */
-    private String injectCspNonceIntoTags(String htmlContent, String nonce, boolean injectIntoScripts, boolean injectIntoStyles) {
-        if (Tools.isEmpty(htmlContent) || Tools.isEmpty(nonce)) {
-            return htmlContent;
-        }
-        // Single regex pattern to match all three tag types (script, style, link)
-        // Uses alternation to match any of: <script..., <style..., <link...rel="stylesheet"...>
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
-            "(<script[^>]*?>)|(<style[^>]*?>)|(<link\\b[^>]*?rel\\s*=\\s*(?:\"stylesheet\"|'stylesheet'|stylesheet)[^>]*?>)", //NOSONAR
-            java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL
-        );
-        java.util.regex.Matcher matcher = pattern.matcher(htmlContent);
-        // Use StringBuilder (no synchronization overhead) with initial capacity
-        StringBuilder sb = new StringBuilder(htmlContent.length());
-        // Pre-compile patterns for each tag type (includes closing '>' to handle plain tags like <style>)
-        java.util.regex.Pattern scriptPattern = java.util.regex.Pattern.compile("(<script)(\\s+[^>]*)?>");
-        java.util.regex.Pattern stylePattern = java.util.regex.Pattern.compile("(<style)(\\s+[^>]*)?>");
-        java.util.regex.Pattern linkPattern = java.util.regex.Pattern.compile("(<link)(\\s+[^>]*)?>");
-        int lastEnd = 0;
-        while (matcher.find()) {
-            // Append text before this match
-            sb.append(htmlContent, lastEnd, matcher.start());
-            String tagContent = matcher.group(0);
-            // Determine which tag type and inject nonce (skip if corresponding CSP directive allows unsafe-inline)
-            String processedTag = processTagForNonce(tagContent, nonce, scriptPattern, stylePattern, linkPattern, injectIntoScripts, injectIntoStyles);
-            sb.append(processedTag);
-            lastEnd = matcher.end();
-        }
-        // Append remaining text after last match
-        sb.append(htmlContent, lastEnd, htmlContent.length());
-        return sb.toString();
-    }
-
-    /**
-     * Processes a single tag (script, style, or link) to inject nonce if not already present.
-     * Skips injection for tag types whose corresponding CSP directive allows unsafe-inline.
-     *
-     * @param tagContent The matched tag string
-     * @param nonce The CSP nonce value
-     * @param scriptPattern Pre-compiled pattern for script tags
-     * @param stylePattern Pre-compiled pattern for style tags
-     * @param linkPattern Pre-compiled pattern for link tags
-     * @param injectIntoScripts Whether to inject nonce into script tags
-     * @param injectIntoStyles Whether to inject nonce into style/link tags
-     * @return Processed tag string
-     */
-    private String processTagForNonce(String tagContent, String nonce, java.util.regex.Pattern scriptPattern,
-                                      java.util.regex.Pattern stylePattern, java.util.regex.Pattern linkPattern,
-                                      boolean injectIntoScripts, boolean injectIntoStyles) {
-        // Check if nonce attribute is already present (lookbehind ensures nonce is preceded by whitespace or letter, not - or ?)
-        if (java.util.regex.Pattern.compile("(?<=[\\sa-z])nonce\\s*=").matcher(tagContent).find()) {
-            return tagContent;
-        }
-        // Extract tag name (handles both <script> and <script type="...">)
-        // Find the end of the tag name (space or '>')
-        int gtIndex = tagContent.indexOf('>');
-        int spaceIndex = tagContent.indexOf(' ');
-        int nameEnd;
-        if (spaceIndex < 0) {
-            nameEnd = gtIndex;
-        } else if (gtIndex < 0) {
-            nameEnd = spaceIndex;
-        } else {
-            nameEnd = Math.min(spaceIndex, gtIndex);
-        }
-        if (nameEnd < 0) {
-            return tagContent;
-        }
-        String tagName = tagContent.substring(0, nameEnd).toLowerCase();
-        // Skip nonce injection for tag types whose CSP directive allows unsafe-inline
-        if (tagName.equals("<script") && !injectIntoScripts) {
-            return tagContent;
-        }
-        if ((tagName.equals("<style") || tagName.equals("<link")) && !injectIntoStyles) {
-            return tagContent;
-        }
-        java.util.regex.Pattern tagSpecificPattern;
-        switch (tagName) {
-            case "<script":
-                tagSpecificPattern = scriptPattern;
-                break;
-            case "<style":
-                tagSpecificPattern = stylePattern;
-                break;
-            case "<link":
-                tagSpecificPattern = linkPattern;
-                break;
-            default:
-                return tagContent;
-        }
-        // Inject nonce attribute after existing attributes (or after tag name)
-        java.util.regex.Matcher tagMatcher = tagSpecificPattern.matcher(tagContent);
-        String injectPoint = tagContent;
-        if (tagMatcher.find()) {
-            String attributes = tagMatcher.group(2);
-            if (Tools.isNotEmpty(attributes)) {
-                injectPoint = tagName + attributes + " nonce=\"" + nonce + "\"";
-            } else {
-                injectPoint = tagName + " nonce=\"" + nonce + "\"";
-            }
-        }
-        return injectPoint + ">";
-    }
-
-    /**
      * Forwards to a template and optionally processes the response body.
      * If showDocMoveStyleToHead is enabled, captures the response, extracts collected styles
      * from components, and inserts them into the head section.
@@ -1891,17 +1779,17 @@ private static String combineCss(String cssStyle)
             PathFilter.setHeader(response, "Content-Security-Policy", "contentSecurityPolicy");
             // Check each directive separately to skip nonce injection only for tag types
             // whose corresponding CSP directive already allows unsafe-inline
-            boolean scriptSrcAllowsUnsafeInline = isDirectiveAllowsUnsafeInline(contentSecurityPolicy, "script-src");
-            boolean styleSrcAllowsUnsafeInline = isDirectiveAllowsUnsafeInline(contentSecurityPolicy, "style-src");
+            boolean scriptSrcAllowsUnsafeInline = NonceHelper.isDirectiveAllowsUnsafeInline(contentSecurityPolicy, "script-src");
+            boolean styleSrcAllowsUnsafeInline = NonceHelper.isDirectiveAllowsUnsafeInline(contentSecurityPolicy, "style-src");
             // Inject nonce into tags, skipping tag types whose directive allows unsafe-inline
-            capturedContent = injectCspNonceIntoTags(capturedContent, cspNonce, !scriptSrcAllowsUnsafeInline, !styleSrcAllowsUnsafeInline);
+            capturedContent = NonceHelper.injectCspNonceIntoTags(capturedContent, cspNonce, !scriptSrcAllowsUnsafeInline, !styleSrcAllowsUnsafeInline);
             // Process inline styles and event handlers for CSP compliance
             // Only process if unsafe-inline is NOT allowed (since browser already allows them)
             if (styleSrcAllowsUnsafeInline == false) {
-                capturedContent = processInlineStyles(capturedContent, cspNonce);
+                capturedContent = NonceHelper.processInlineStyles(capturedContent, cspNonce);
             }
             if (scriptSrcAllowsUnsafeInline == false) {
-                capturedContent = processInlineEventHandlers(capturedContent, cspNonce);
+                capturedContent = NonceHelper.processInlineEventHandlers(capturedContent, cspNonce);
             }
         }
 
@@ -1913,202 +1801,5 @@ private static String combineCss(String cssStyle)
 
         // Clear collected styles
         StyleToHeadHelper.clearCollectedStyles(request);
-    }
-
-    /**
-     * Processes inline styles by replacing them with data attributes and injecting CSS rules with nonce.
-     * For elements with inline style="...", replaces with data-inline-style="counter" and generates
-     * CSS rules like [data-inline-style="1"] { property: value !important; }.
-     *
-     * @param htmlContent The HTML content
-     * @param nonce The CSP nonce
-     * @return Processed HTML with inline styles replaced and CSS injected
-     */
-    private String processInlineStyles(String htmlContent, String nonce) {
-        if (Tools.isEmpty(htmlContent) || Tools.isEmpty(nonce)) {
-            return htmlContent;
-        }
-
-        // Find all elements with inline style attributes (handles both double and single quotes)
-        java.util.regex.Pattern stylePattern = java.util.regex.Pattern.compile(
-            "(\\s+style\\s*=\\s*)(\"([^\"]*)\")|(\\s+style\\s*=\\s*)('([^']*)')",
-            java.util.regex.Pattern.CASE_INSENSITIVE
-        );
-        java.util.regex.Matcher matcher = stylePattern.matcher(htmlContent);
-
-        StringBuilder cssRules = new StringBuilder();
-        int styleCounter = 0;
-        StringBuilder processedHtml = new StringBuilder(htmlContent.length());
-        int lastEnd = 0;
-
-        while (matcher.find()) {
-            styleCounter++;
-            String quotePrefix;
-            String styleValue;
-
-            // Determine which quote style was used (group 1 = double-quoted prefix, group 4 = single-quoted prefix)
-            if (matcher.group(1) != null) {
-                quotePrefix = matcher.group(1);
-                styleValue = matcher.group(3); // double-quoted value
-            } else {
-                quotePrefix = matcher.group(4);
-                styleValue = matcher.group(6); // single-quoted value
-            }
-
-            String dataAttr = quotePrefix.replace("style", "data-inline-style") + "\"nonce" + styleCounter + "\"";
-
-            // Append text before this match
-            processedHtml.append(htmlContent, lastEnd, matcher.start());
-            processedHtml.append(dataAttr);
-
-            // Generate CSS rule with !important for each property
-            cssRules.append("       [data-inline-style=\"nonce").append(styleCounter).append("\"] {");
-
-            // Parse CSS properties and add !important to each
-            String[] properties = styleValue.split(";");
-            for (String prop : properties) {
-                String trimmed = prop.trim();
-                if (Tools.isNotEmpty(trimmed) && trimmed.contains(":")) {
-                    // Remove trailing semicolon if present, then append " !important;"
-                    String propPart = trimmed.endsWith(";") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
-                    cssRules.append(propPart).append(" !important;");
-                }
-            }
-            cssRules.append("}\n");
-
-            lastEnd = matcher.end();
-        }
-
-        // Append remaining text
-        processedHtml.append(htmlContent, lastEnd, htmlContent.length());
-
-        // If we found inline styles, inject CSS with nonce
-        if (styleCounter > 0) {
-            String styleInjection = "\n<style nonce=\"" + nonce + "\">\n" + cssRules.toString() + "</style>\n";
-            // Find the closing </body> tag and insert before it, or append at end
-            int bodyCloseIndex = processedHtml.lastIndexOf("</body>");
-            if (bodyCloseIndex > 0) {
-                processedHtml.insert(bodyCloseIndex, styleInjection);
-            } else {
-                processedHtml.append(styleInjection);
-            }
-        }
-
-        return processedHtml.toString();
-    }
-
-    /**
-     * Processes inline event handlers by replacing them with data attributes and injecting JavaScript with nonce.
-     * For elements with inline event handlers (onclick, onmouseover, etc.), replaces with
-     * data-inline-onclick="counter" and generates JavaScript code to restore the handlers.
-     *
-     * @param htmlContent The HTML content
-     * @param nonce The CSP nonce
-     * @return Processed HTML with inline event handlers replaced and JavaScript injected
-     */
-    private String processInlineEventHandlers(String htmlContent, String nonce) {
-        if (Tools.isEmpty(htmlContent) || Tools.isEmpty(nonce)) {
-            return htmlContent;
-        }
-
-        // Find all inline event handlers (onclick, onmouseover, onmouseout, onfocus, onblur, etc.)
-        // Handles both double and single quotes
-        java.util.regex.Pattern eventPattern = java.util.regex.Pattern.compile(
-            "(\\s+(onclick|onmouseover|onmouseout|onfocus|onblur|onkeydown|onkeyup|onsubmit|onchange|oninput|ondblclick|oncontextmenu|ondrag|ondrop)\\s*=\\s*)(\"([^\"]*)\")|(\\s+(onclick|onmouseover|onmouseout|onfocus|onblur|onkeydown|onkeyup|onsubmit|onchange|oninput|ondblclick|oncontextmenu|ondrop)\\s*=\\s*)('([^']*)')", //NOSONAR
-            java.util.regex.Pattern.CASE_INSENSITIVE
-        );
-        java.util.regex.Matcher matcher = eventPattern.matcher(htmlContent);
-
-        StringBuilder jsCode = new StringBuilder();
-        java.util.Map<String, Integer> eventCounters = new java.util.HashMap<>();
-        StringBuilder processedHtml = new StringBuilder(htmlContent.length());
-        int lastEnd = 0;
-
-        while (matcher.find()) {
-            String quotePrefix;
-            String eventType;
-            String handlerValue;
-
-            // Determine which quote style was used
-            if (matcher.group(1) != null) {
-                quotePrefix = matcher.group(1);
-                eventType = matcher.group(2).toLowerCase();
-                handlerValue = matcher.group(4); // double-quoted
-            } else {
-                quotePrefix = matcher.group(5);
-                eventType = matcher.group(6).toLowerCase();
-                handlerValue = matcher.group(8); // single-quoted
-            }
-
-            //unfilter values
-            handlerValue = handlerValue.replace("&#39;", "'");
-            handlerValue = handlerValue.replace("&quot;", "\"");
-
-            // Get or create counter for this event type
-            int counter = eventCounters.getOrDefault(eventType, 0) + 1;
-            eventCounters.put(eventType, counter);
-
-            String dataAttr = quotePrefix.replace(eventType, "data-inline-" + eventType) + "\"nonce" + counter + "\"";
-
-            // Append text before this match
-            processedHtml.append(htmlContent, lastEnd, matcher.start());
-            processedHtml.append(dataAttr);
-
-            // Generate JavaScript to restore the event handler
-            jsCode.append("       document.querySelectorAll('[data-inline-").append(eventType).append("=\"nonce").append(counter).append("\"]').forEach(function(el) {");
-            jsCode.append("el.").append(eventType).append(" = function(event) {").append(handlerValue).append(";};");
-            jsCode.append("});\n");
-
-            lastEnd = matcher.end();
-        }
-
-        // Append remaining text
-        processedHtml.append(htmlContent, lastEnd, htmlContent.length());
-
-        // If we found inline event handlers, inject JavaScript with nonce
-        if (!eventCounters.isEmpty()) {
-            String scriptInjection = "\n<script nonce=\"" + nonce + "\">\n" + jsCode.toString() + "</script>\n";
-            // Find the closing </body> tag and insert before it, or append at end
-            int bodyCloseIndex = processedHtml.lastIndexOf("</body>");
-            if (bodyCloseIndex > 0) {
-                processedHtml.insert(bodyCloseIndex, scriptInjection);
-            } else {
-                processedHtml.append(scriptInjection);
-            }
-        }
-
-        return processedHtml.toString();
-    }
-
-    /**
-     * Checks if a specific CSP directive allows 'unsafe-inline'.
-     * Parses using indexOf to find the directive start and end (next ';' or end of string),
-     * then checks if 'unsafe-inline' exists within that range.
-     *
-     * @param cspValue The full CSP configuration string
-     * @param directiveName The directive name to check (e.g., "script-src", "style-src")
-     * @return true if the directive allows 'unsafe-inline'
-     */
-    private static boolean isDirectiveAllowsUnsafeInline(String cspValue, String directiveName) {
-        // Find the directive by looking for the name followed by whitespace
-        int directiveIndex = cspValue.indexOf(directiveName);
-        if (directiveIndex < 0) {
-            return false;
-        }
-        // Move past the directive name to the value part
-        int valueStart = directiveIndex + directiveName.length();
-        // Skip whitespace after directive name
-        while (valueStart < cspValue.length() && Character.isWhitespace(cspValue.charAt(valueStart))) {
-            valueStart++;
-        }
-        // Find the end of this directive (next ';' or end of string)
-        int directiveEnd = cspValue.indexOf(';', valueStart);
-        if (directiveEnd < 0) {
-            directiveEnd = cspValue.length();
-        }
-        // Check if 'unsafe-inline' appears within this directive's value
-        String directiveValue = cspValue.substring(valueStart, directiveEnd);
-        if (directiveValue.contains("{nonce}")) return false;
-        return directiveValue.contains("unsafe-inline");
     }
 }

--- a/src/main/java/sk/iway/iwcm/doc/showdoc/NonceHelper.java
+++ b/src/main/java/sk/iway/iwcm/doc/showdoc/NonceHelper.java
@@ -1,0 +1,327 @@
+package sk.iway.iwcm.doc.showdoc;
+
+import sk.iway.iwcm.Tools;
+
+/**
+ * Helper class for Content-Security-Policy (CSP) nonce functionality.
+ * Handles nonce injection into HTML tags, inline style/event handler migration,
+ * and CSP configuration parsing.
+ */
+public final class NonceHelper {
+
+    private NonceHelper() {
+        // Utility class - no instantiation
+    }
+
+
+    /**
+     * Injects CSP nonce into <script>, <style>, and <link rel="stylesheet"> tags in a single pass.
+     * Optimized for memory efficiency: uses single StringBuilder, processes all tag types in one pass.
+     *
+     * @param htmlContent The HTML content to process
+     * @param nonce The CSP nonce value
+     * @param injectIntoScripts Whether to inject nonce into <script> tags (false if script-src allows unsafe-inline)
+     * @param injectIntoStyles Whether to inject nonce into <style> and <link> tags (false if style-src allows unsafe-inline)
+     * @return HTML content with nonce injected into eligible tags
+     */
+    public static String injectCspNonceIntoTags(String htmlContent, String nonce, boolean injectIntoScripts, boolean injectIntoStyles) {
+        if (Tools.isEmpty(htmlContent) || Tools.isEmpty(nonce)) {
+            return htmlContent;
+        }
+        // Single regex pattern to match all three tag types (script, style, link)
+        // Uses alternation to match any of: <script..., <style..., <link...rel="stylesheet"...>
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
+            "(<script[^>]*?>)|(<style[^>]*?>)|(<link\\b[^>]*?rel\\s*=\\s*(?:\"stylesheet\"|'stylesheet'|stylesheet)[^>]*?>)", //NOSONAR
+            java.util.regex.Pattern.CASE_INSENSITIVE | java.util.regex.Pattern.DOTALL
+        );
+        java.util.regex.Matcher matcher = pattern.matcher(htmlContent);
+        // Use StringBuilder (no synchronization overhead) with initial capacity
+        StringBuilder sb = new StringBuilder(htmlContent.length());
+        // Pre-compile patterns for each tag type (includes closing '>' to handle plain tags like <style>)
+        java.util.regex.Pattern scriptPattern = java.util.regex.Pattern.compile("(<script)(\\s+[^>]*)?>");
+        java.util.regex.Pattern stylePattern = java.util.regex.Pattern.compile("(<style)(\\s+[^>]*)?>");
+        java.util.regex.Pattern linkPattern = java.util.regex.Pattern.compile("(<link)(\\s+[^>]*)?>");
+        int lastEnd = 0;
+        while (matcher.find()) {
+            // Append text before this match
+            sb.append(htmlContent, lastEnd, matcher.start());
+            String tagContent = matcher.group(0);
+            // Determine which tag type and inject nonce (skip if corresponding CSP directive allows unsafe-inline)
+            String processedTag = processTagForNonce(tagContent, nonce, scriptPattern, stylePattern, linkPattern, injectIntoScripts, injectIntoStyles);
+            sb.append(processedTag);
+            lastEnd = matcher.end();
+        }
+        // Append remaining text after last match
+        sb.append(htmlContent, lastEnd, htmlContent.length());
+        return sb.toString();
+    }
+
+    /**
+     * Processes a single tag (script, style, or link) to inject nonce if not already present.
+     * Skips injection for tag types whose corresponding CSP directive allows unsafe-inline.
+     *
+     * @param tagContent The matched tag string
+     * @param nonce The CSP nonce value
+     * @param scriptPattern Pre-compiled pattern for script tags
+     * @param stylePattern Pre-compiled pattern for style tags
+     * @param linkPattern Pre-compiled pattern for link tags
+     * @param injectIntoScripts Whether to inject nonce into script tags
+     * @param injectIntoStyles Whether to inject nonce into style/link tags
+     * @return Processed tag string
+     */
+    protected static String processTagForNonce(String tagContent, String nonce, java.util.regex.Pattern scriptPattern,
+                                      java.util.regex.Pattern stylePattern, java.util.regex.Pattern linkPattern,
+                                      boolean injectIntoScripts, boolean injectIntoStyles) {
+        // Check if nonce attribute is already present (lookbehind ensures nonce is preceded by whitespace or letter, not - or ?)
+        if (java.util.regex.Pattern.compile("(?<=[\\sa-z])nonce\\s*=").matcher(tagContent).find()) {
+            return tagContent;
+        }
+        // Extract tag name (handles both <script> and <script type="...">)
+        // Find the end of the tag name (space or '>')
+        int gtIndex = tagContent.indexOf('>');
+        int spaceIndex = tagContent.indexOf(' ');
+        int nameEnd;
+        if (spaceIndex < 0) {
+            nameEnd = gtIndex;
+        } else if (gtIndex < 0) {
+            nameEnd = spaceIndex;
+        } else {
+            nameEnd = Math.min(spaceIndex, gtIndex);
+        }
+        if (nameEnd < 0) {
+            return tagContent;
+        }
+        String tagName = tagContent.substring(0, nameEnd).toLowerCase();
+        // Skip nonce injection for tag types whose CSP directive allows unsafe-inline
+        if (tagName.equals("<script") && !injectIntoScripts) {
+            return tagContent;
+        }
+        if ((tagName.equals("<style") || tagName.equals("<link")) && !injectIntoStyles) {
+            return tagContent;
+        }
+        java.util.regex.Pattern tagSpecificPattern;
+        switch (tagName) {
+            case "<script":
+                tagSpecificPattern = scriptPattern;
+                break;
+            case "<style":
+                tagSpecificPattern = stylePattern;
+                break;
+            case "<link":
+                tagSpecificPattern = linkPattern;
+                break;
+            default:
+                return tagContent;
+        }
+        // Inject nonce attribute after existing attributes (or after tag name)
+        java.util.regex.Matcher tagMatcher = tagSpecificPattern.matcher(tagContent);
+        String injectPoint = tagContent;
+        if (tagMatcher.find()) {
+            String attributes = tagMatcher.group(2);
+            if (Tools.isNotEmpty(attributes)) {
+                injectPoint = tagName + attributes + " nonce=\"" + nonce + "\"";
+            } else {
+                injectPoint = tagName + " nonce=\"" + nonce + "\"";
+            }
+        }
+        return injectPoint + ">";
+    }
+
+
+    /**
+     * Processes inline styles by replacing them with data attributes and injecting CSS rules with nonce.
+     * For elements with inline style="...", replaces with data-inline-style="counter" and generates
+     * CSS rules like [data-inline-style="1"] { property: value !important; }.
+     *
+     * @param htmlContent The HTML content
+     * @param nonce The CSP nonce
+     * @return Processed HTML with inline styles replaced and CSS injected
+     */
+    public static String processInlineStyles(String htmlContent, String nonce) {
+        if (Tools.isEmpty(htmlContent) || Tools.isEmpty(nonce)) {
+            return htmlContent;
+        }
+
+        // Find all elements with inline style attributes (handles both double and single quotes)
+        java.util.regex.Pattern stylePattern = java.util.regex.Pattern.compile(
+            "(\\s+style\\s*=\\s*)(\"([^\"]*)\")|(\\s+style\\s*=\\s*)('([^']*)')",
+            java.util.regex.Pattern.CASE_INSENSITIVE
+        );
+        java.util.regex.Matcher matcher = stylePattern.matcher(htmlContent);
+
+        StringBuilder cssRules = new StringBuilder();
+        int styleCounter = 0;
+        StringBuilder processedHtml = new StringBuilder(htmlContent.length());
+        int lastEnd = 0;
+
+        while (matcher.find()) {
+            styleCounter++;
+            String quotePrefix;
+            String styleValue;
+
+            // Determine which quote style was used (group 1 = double-quoted prefix, group 4 = single-quoted prefix)
+            if (matcher.group(1) != null) {
+                quotePrefix = matcher.group(1);
+                styleValue = matcher.group(3); // double-quoted value
+            } else {
+                quotePrefix = matcher.group(4);
+                styleValue = matcher.group(6); // single-quoted value
+            }
+
+            String dataAttr = quotePrefix.replace("style", "data-inline-style") + "\"nonce" + styleCounter + "\"";
+
+            // Append text before this match
+            processedHtml.append(htmlContent, lastEnd, matcher.start());
+            processedHtml.append(dataAttr);
+
+            // Generate CSS rule with !important for each property
+            cssRules.append("       [data-inline-style=\"nonce").append(styleCounter).append("\"] {");
+
+            // Parse CSS properties and add !important to each
+            String[] properties = styleValue.split(";");
+            for (String prop : properties) {
+                String trimmed = prop.trim();
+                if (Tools.isNotEmpty(trimmed) && trimmed.contains(":")) {
+                    // Remove trailing semicolon if present, then append " !important;"
+                    String propPart = trimmed.endsWith(";") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+                    cssRules.append(propPart).append(" !important;");
+                }
+            }
+            cssRules.append("}\n");
+
+            lastEnd = matcher.end();
+        }
+
+        // Append remaining text
+        processedHtml.append(htmlContent, lastEnd, htmlContent.length());
+
+        // If we found inline styles, inject CSS with nonce
+        if (styleCounter > 0) {
+            String styleInjection = "\n<style nonce=\"" + nonce + "\">\n" + cssRules.toString() + "</style>\n";
+            // Find the closing </body> tag and insert before it, or append at end
+            int bodyCloseIndex = processedHtml.lastIndexOf("</body>");
+            if (bodyCloseIndex > 0) {
+                processedHtml.insert(bodyCloseIndex, styleInjection);
+            } else {
+                processedHtml.append(styleInjection);
+            }
+        }
+
+        return processedHtml.toString();
+    }
+
+    /**
+     * Processes inline event handlers by replacing them with data attributes and injecting JavaScript with nonce.
+     * For elements with inline event handlers (onclick, onmouseover, etc.), replaces with
+     * data-inline-onclick="counter" and generates JavaScript code to restore the handlers.
+     *
+     * @param htmlContent The HTML content
+     * @param nonce The CSP nonce
+     * @return Processed HTML with inline event handlers replaced and JavaScript injected
+     */
+    public static String processInlineEventHandlers(String htmlContent, String nonce) {
+        if (Tools.isEmpty(htmlContent) || Tools.isEmpty(nonce)) {
+            return htmlContent;
+        }
+
+        // Find all inline event handlers (onclick, onmouseover, onmouseout, onfocus, onblur, etc.)
+        // Handles both double and single quotes
+        java.util.regex.Pattern eventPattern = java.util.regex.Pattern.compile(
+            "(\\s+(onclick|onmouseover|onmouseout|onfocus|onblur|onkeydown|onkeyup|onsubmit|onchange|oninput|ondblclick|oncontextmenu|ondrag|ondrop)\\s*=\\s*)(\"([^\"]*)\")|(\\s+(onclick|onmouseover|onmouseout|onfocus|onblur|onkeydown|onkeyup|onsubmit|onchange|oninput|ondblclick|oncontextmenu|ondrop)\\s*=\\s*)('([^']*)')", //NOSONAR
+            java.util.regex.Pattern.CASE_INSENSITIVE
+        );
+        java.util.regex.Matcher matcher = eventPattern.matcher(htmlContent);
+
+        StringBuilder jsCode = new StringBuilder();
+        java.util.Map<String, Integer> eventCounters = new java.util.HashMap<>();
+        StringBuilder processedHtml = new StringBuilder(htmlContent.length());
+        int lastEnd = 0;
+
+        while (matcher.find()) {
+            String quotePrefix;
+            String eventType;
+            String handlerValue;
+
+            // Determine which quote style was used
+            if (matcher.group(1) != null) {
+                quotePrefix = matcher.group(1);
+                eventType = matcher.group(2).toLowerCase();
+                handlerValue = matcher.group(4); // double-quoted
+            } else {
+                quotePrefix = matcher.group(5);
+                eventType = matcher.group(6).toLowerCase();
+                handlerValue = matcher.group(8); // single-quoted
+            }
+
+            //unfilter values
+            handlerValue = handlerValue.replace("&#39;", "'");
+            handlerValue = handlerValue.replace("&quot;", "\"");
+
+            // Get or create counter for this event type
+            int counter = eventCounters.getOrDefault(eventType, 0) + 1;
+            eventCounters.put(eventType, counter);
+
+            String dataAttr = quotePrefix.replace(eventType, "data-inline-" + eventType) + "\"nonce" + counter + "\"";
+
+            // Append text before this match
+            processedHtml.append(htmlContent, lastEnd, matcher.start());
+            processedHtml.append(dataAttr);
+
+            // Generate JavaScript to restore the event handler
+            jsCode.append("       document.querySelectorAll('[data-inline-").append(eventType).append("=\"nonce").append(counter).append("\"]').forEach(function(el) {");
+            jsCode.append("el.").append(eventType).append(" = function(event) {").append(handlerValue).append(";};");
+            jsCode.append("});\n");
+
+            lastEnd = matcher.end();
+        }
+
+        // Append remaining text
+        processedHtml.append(htmlContent, lastEnd, htmlContent.length());
+
+        // If we found inline event handlers, inject JavaScript with nonce
+        if (!eventCounters.isEmpty()) {
+            String scriptInjection = "\n<script nonce=\"" + nonce + "\">\n" + jsCode.toString() + "</script>\n";
+            // Find the closing </body> tag and insert before it, or append at end
+            int bodyCloseIndex = processedHtml.lastIndexOf("</body>");
+            if (bodyCloseIndex > 0) {
+                processedHtml.insert(bodyCloseIndex, scriptInjection);
+            } else {
+                processedHtml.append(scriptInjection);
+            }
+        }
+
+        return processedHtml.toString();
+    }
+
+    /**
+     * Checks if a specific CSP directive allows 'unsafe-inline'.
+     * Parses using indexOf to find the directive start and end (next ';' or end of string),
+     * then checks if 'unsafe-inline' exists within that range.
+     *
+     * @param cspValue The full CSP configuration string
+     * @param directiveName The directive name to check (e.g., "script-src", "style-src")
+     * @return true if the directive allows 'unsafe-inline'
+     */
+    public static boolean isDirectiveAllowsUnsafeInline(String cspValue, String directiveName) {
+        // Find the directive by looking for the name followed by whitespace
+        int directiveIndex = cspValue.indexOf(directiveName);
+        if (directiveIndex < 0) {
+            return false;
+        }
+        // Move past the directive name to the value part
+        int valueStart = directiveIndex + directiveName.length();
+        // Skip whitespace after directive name
+        while (valueStart < cspValue.length() && Character.isWhitespace(cspValue.charAt(valueStart))) {
+            valueStart++;
+        }
+        // Find the end of this directive (next ';' or end of string)
+        int directiveEnd = cspValue.indexOf(';', valueStart);
+        if (directiveEnd < 0) {
+            directiveEnd = cspValue.length();
+        }
+        // Check if 'unsafe-inline' appears within this directive's value
+        String directiveValue = cspValue.substring(valueStart, directiveEnd);
+        if (directiveValue.contains("{nonce}")) return false;
+        return directiveValue.contains("unsafe-inline");
+    }
+}

--- a/src/main/java/sk/iway/iwcm/doc/showdoc/NonceHelper.java
+++ b/src/main/java/sk/iway/iwcm/doc/showdoc/NonceHelper.java
@@ -118,9 +118,9 @@ public final class NonceHelper {
         String injectPoint = tagContent;
         if (tagMatcher.find()) {
             String attributes = tagMatcher.group(2);
-            //
-            attributes = attributes.replaceAll("\\s*/\\s*$", "");
+            // Handle tags with no attributes (group 2 is null)
             if (Tools.isNotEmpty(attributes)) {
+                attributes = attributes.replaceAll("\\s*/\\s*$", "");
                 injectPoint = tagName + attributes + " nonce=\"" + nonce + "\"";
             } else {
                 injectPoint = tagName + " nonce=\"" + nonce + "\"";

--- a/src/main/java/sk/iway/iwcm/doc/showdoc/NonceHelper.java
+++ b/src/main/java/sk/iway/iwcm/doc/showdoc/NonceHelper.java
@@ -38,9 +38,9 @@ public final class NonceHelper {
         // Use StringBuilder (no synchronization overhead) with initial capacity
         StringBuilder sb = new StringBuilder(htmlContent.length());
         // Pre-compile patterns for each tag type (includes closing '>' to handle plain tags like <style>)
-        java.util.regex.Pattern scriptPattern = java.util.regex.Pattern.compile("(<script)(\\s+[^>]*)?>");
-        java.util.regex.Pattern stylePattern = java.util.regex.Pattern.compile("(<style)(\\s+[^>]*)?>");
-        java.util.regex.Pattern linkPattern = java.util.regex.Pattern.compile("(<link)(\\s+[^>]*)?>");
+        java.util.regex.Pattern scriptPattern = java.util.regex.Pattern.compile("(<script)(\\s+[^>]*)?>", java.util.regex.Pattern.CASE_INSENSITIVE);
+        java.util.regex.Pattern stylePattern = java.util.regex.Pattern.compile("(<style)(\\s+[^>]*)?>", java.util.regex.Pattern.CASE_INSENSITIVE);
+        java.util.regex.Pattern linkPattern = java.util.regex.Pattern.compile("(<link)(\\s+[^>]*)?>", java.util.regex.Pattern.CASE_INSENSITIVE);
         int lastEnd = 0;
         while (matcher.find()) {
             // Append text before this match
@@ -118,6 +118,8 @@ public final class NonceHelper {
         String injectPoint = tagContent;
         if (tagMatcher.find()) {
             String attributes = tagMatcher.group(2);
+            //
+            attributes = attributes.replaceAll("\\s*/\\s*$", "");
             if (Tools.isNotEmpty(attributes)) {
                 injectPoint = tagName + attributes + " nonce=\"" + nonce + "\"";
             } else {
@@ -168,7 +170,7 @@ public final class NonceHelper {
                 styleValue = matcher.group(6); // single-quoted value
             }
 
-            String dataAttr = quotePrefix.replace("style", "data-inline-style") + "\"nonce" + styleCounter + "\"";
+            String dataAttr = quotePrefix.replaceAll("(?i)style", "data-inline-style") + "\"nonce" + styleCounter + "\"";
 
             // Append text before this match
             processedHtml.append(htmlContent, lastEnd, matcher.start());
@@ -263,7 +265,7 @@ public final class NonceHelper {
             int counter = eventCounters.getOrDefault(eventType, 0) + 1;
             eventCounters.put(eventType, counter);
 
-            String dataAttr = quotePrefix.replace(eventType, "data-inline-" + eventType) + "\"nonce" + counter + "\"";
+            String dataAttr = quotePrefix.replaceAll("(?i)" + eventType, "data-inline-" + eventType) + "\"nonce" + counter + "\"";
 
             // Append text before this match
             processedHtml.append(htmlContent, lastEnd, matcher.start());

--- a/src/main/java/sk/iway/iwcm/doc/showdoc/NonceHelper.java
+++ b/src/main/java/sk/iway/iwcm/doc/showdoc/NonceHelper.java
@@ -182,8 +182,10 @@ public final class NonceHelper {
             for (String prop : properties) {
                 String trimmed = prop.trim();
                 if (Tools.isNotEmpty(trimmed) && trimmed.contains(":")) {
-                    // Remove trailing semicolon if present, then append " !important;"
+                    // Remove trailing semicolon if present
                     String propPart = trimmed.endsWith(";") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+                    // Escape CSS special characters to prevent breaking out of the rule block
+                    propPart = propPart.replace("}", "\\}").replace("{", "\\{");
                     cssRules.append(propPart).append(" !important;");
                 }
             }
@@ -319,6 +321,7 @@ public final class NonceHelper {
         if (directiveEnd < 0) {
             directiveEnd = cspValue.length();
         }
+        // Use fast check instead tokenizing
         // Check if 'unsafe-inline' appears within this directive's value
         String directiveValue = cspValue.substring(valueStart, directiveEnd);
         if (directiveValue.contains("{nonce}")) return false;

--- a/src/main/webapp/apps/form/mvc/default.css
+++ b/src/main/webapp/apps/form/mvc/default.css
@@ -22,3 +22,8 @@
 .multistep-form-app .form-group.mf-visibility-animated.mf-hidden input {
     display: none;
 }
+
+.multistep-form-app .mf-error-list {
+    margin: 0px;
+    padding-left: 20px;
+}

--- a/src/main/webapp/apps/form/mvc/multistep-form.js
+++ b/src/main/webapp/apps/form/mvc/multistep-form.js
@@ -717,7 +717,7 @@ export class MultistepForm {
                     const errDiv = $(this.wrapper).find('div.cs-error-' + fieldName);
                     const errorMsgArr = String(errorMsg).split('\n');
                     errDiv.html('');
-                    let html = "<ul style='margin:0px; padding-left: 20px;'>";
+                    let html = "<ul class='mf-error-list'>";
                     for (const msg of errorMsgArr) html += `<li>${msg}</li>`;
                     html += '</ul>';
                     errDiv.html(html);

--- a/src/main/webapp/components/_common/cleditor/jquery.cleditor.js
+++ b/src/main/webapp/components/_common/cleditor/jquery.cleditor.js
@@ -840,7 +840,7 @@
             editor.$frame.remove();
 
         // Create a new iframe
-        var $frame = editor.$frame = $('<iframe frameborder="0" src="javascript:true;" />')
+        var $frame = editor.$frame = $('<iframe frameborder="0"/>')
             .hide()
             .appendTo($main);
 

--- a/src/test/java/sk/iway/iwcm/CspNonceTest.java
+++ b/src/test/java/sk/iway/iwcm/CspNonceTest.java
@@ -131,8 +131,13 @@ class CspNonceTest extends BaseWebjetTest {
 
 	@Test
 	void testSetHeaderNoNoncePlaceholderWhenDisabled() {
-		Constants.setBoolean("cspNonceEnabled", false);
 		Constants.setString("contentSecurityPolicy", "default-src 'self'");
+
+		HttpSession mockSession = mock(HttpSession.class);
+		when(mockSession.getId()).thenReturn("test-session-id");
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+		when(mockRequest.getSession()).thenReturn(mockSession);
+		SetCharacterEncodingFilter.registerDataContext(mockRequest);
 
 		HttpServletResponse mockResponse = mock(HttpServletResponse.class);
 		PathFilter.setHeader(mockResponse, "Content-Security-Policy", "contentSecurityPolicy");
@@ -588,5 +593,156 @@ class CspNonceTest extends BaseWebjetTest {
 		} catch (Exception e) {
 			throw new RuntimeException("Failed to invoke processInlineEventHandlers", e);
 		}
+	}
+
+	// ==================== Helper methods for isUnsafeInlineAllowedInCsp ====================
+
+	private boolean isUnsafeInlineAllowedInCsp(String cspValue) {
+		try {
+			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("isUnsafeInlineAllowedInCsp", String.class);
+			method.setAccessible(true);
+			return (Boolean) method.invoke(null, cspValue);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to invoke isUnsafeInlineAllowedInCsp", e);
+		}
+	}
+
+	private boolean isDirectiveAllowsUnsafeInline(String cspValue, String directiveName) {
+		try {
+			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("isDirectiveAllowsUnsafeInline", String.class, String.class);
+			method.setAccessible(true);
+			return (Boolean) method.invoke(null, cspValue, directiveName);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to invoke isDirectiveAllowsUnsafeInline", e);
+		}
+	}
+
+	private String injectCspNonceIntoTags(ShowDoc showDoc, String htmlContent, String nonce) {
+		return injectCspNonceIntoTags(showDoc, htmlContent, nonce, true, true);
+	}
+
+	private String injectCspNonceIntoTags(ShowDoc showDoc, String htmlContent, String nonce, boolean injectIntoScripts, boolean injectIntoStyles) {
+		try {
+			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("injectCspNonceIntoTags", String.class, String.class, boolean.class, boolean.class);
+			method.setAccessible(true);
+			return (String) method.invoke(showDoc, htmlContent, nonce, injectIntoScripts, injectIntoStyles);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to invoke injectCspNonceIntoTags", e);
+		}
+	}
+
+	@Test
+	void testIsUnsafeInlineAllowedInCspEmpty() {
+		ShowDoc showDoc = new ShowDoc();
+		assertFalse(isUnsafeInlineAllowedInCsp(null), "Null CSP should return false");
+		assertFalse(isUnsafeInlineAllowedInCsp(""), "Empty CSP should return false");
+	}
+
+	@Test
+	void testIsUnsafeInlineAllowedInCspNoUnsafeInline() {
+		String csp = "default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https:";
+		assertFalse(isUnsafeInlineAllowedInCsp(csp), "CSP without unsafe-inline should return false");
+	}
+
+	@Test
+	void testIsUnsafeInlineAllowedInCspScriptSrcHasUnsafeInline() {
+		String csp = "default-src 'self'; script-src 'self' 'unsafe-inline' {nonce}; style-src 'self'";
+		assertTrue(isUnsafeInlineAllowedInCsp(csp), "CSP with unsafe-inline in script-src should return true");
+	}
+
+	@Test
+	void testIsUnsafeInlineAllowedInCspStyleSrcHasUnsafeInline() {
+		String csp = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'";
+		assertTrue(isUnsafeInlineAllowedInCsp(csp), "CSP with unsafe-inline in style-src should return true");
+	}
+
+	@Test
+	void testIsUnsafeInlineAllowedInCspBothHaveUnsafeInline() {
+		String csp = "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";
+		assertTrue(isUnsafeInlineAllowedInCsp(csp), "CSP with unsafe-inline in both should return true");
+	}
+
+	@Test
+	void testIsUnsafeInlineAllowedInCspOnlyDefaultSrc() {
+		String csp = "default-src 'self' 'unsafe-inline'; script-src 'self'";
+		assertFalse(isUnsafeInlineAllowedInCsp(csp), "unsafe-inline in default-src only should return false");
+	}
+
+	@Test
+	void testIsUnsafeInlineAllowedInCspLastDirective() {
+		String csp = "default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https: 'unsafe-inline'";
+		assertTrue(isUnsafeInlineAllowedInCsp(csp), "unsafe-inline in last directive should be detected");
+	}
+
+	@Test
+	void testIsDirectiveAllowsUnsafeInlineScriptSrc() {
+		String csp = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self'";
+		assertTrue(isDirectiveAllowsUnsafeInline(csp, "script-src"), "script-src with unsafe-inline should return true");
+	}
+
+	@Test
+	void testIsDirectiveAllowsUnsafeInlineStyleSrc() {
+		String csp = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'";
+		assertTrue(isDirectiveAllowsUnsafeInline(csp, "style-src"), "style-src with unsafe-inline should return true");
+	}
+
+	@Test
+	void testIsDirectiveAllowsUnsafeInlineNotPresent() {
+		String csp = "default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https:";
+		assertFalse(isDirectiveAllowsUnsafeInline(csp, "script-src"), "script-src without unsafe-inline should return false");
+		assertFalse(isDirectiveAllowsUnsafeInline(csp, "style-src"), "style-src without unsafe-inline should return false");
+	}
+
+	@Test
+	void testIsDirectiveAllowsUnsafeInlineWrongDirective() {
+		String csp = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self'";
+		assertTrue(isDirectiveAllowsUnsafeInline(csp, "script-src"), "script-src with unsafe-inline should return true");
+		assertFalse(isDirectiveAllowsUnsafeInline(csp, "style-src"), "style-src without unsafe-inline should return false");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsScriptSrcAllowsUnsafeInline() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><script>console.log('test');</script><style>.a { color: red; }</style></body></html>";
+		// script-src allows unsafe-inline, style-src does not
+		String result = injectCspNonceIntoTags(showDoc, input, "testNonce", false, true);
+		// Script tag should NOT get nonce (script-src allows unsafe-inline)
+		assertFalse(result.contains("<script nonce=\"testNonce\">"), "Script tag should not get nonce when script-src allows unsafe-inline");
+		// Style tag SHOULD get nonce (style-src does not allow unsafe-inline)
+		assertTrue(result.contains("<style nonce=\"testNonce\">"), "Style tag should get nonce when style-src does not allow unsafe-inline");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsStyleSrcAllowsUnsafeInline() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><script>console.log('test');</script><style>.a { color: red; }</style></body></html>";
+		// script-src does not allow unsafe-inline, style-src does
+		String result = injectCspNonceIntoTags(showDoc, input, "testNonce", true, false);
+		// Script tag SHOULD get nonce (script-src does not allow unsafe-inline)
+		assertTrue(result.contains("<script nonce=\"testNonce\">"), "Script tag should get nonce when script-src does not allow unsafe-inline");
+		// Style tag should NOT get nonce (style-src allows unsafe-inline)
+		assertFalse(result.contains("<style nonce=\"testNonce\">"), "Style tag should not get nonce when style-src allows unsafe-inline");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsBothAllowUnsafeInline() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><script>console.log('test');</script><style>.a { color: red; }</style></body></html>";
+		// Both directives allow unsafe-inline
+		String result = injectCspNonceIntoTags(showDoc, input, "testNonce", false, false);
+		// Neither tag should get nonce
+		assertFalse(result.contains("nonce=\"testNonce\""), "No nonce should be injected when both directives allow unsafe-inline");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsLinkStylesheetScriptSrcAllowsUnsafeInline() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><link rel=\"stylesheet\" href=\"/css/main.css\"></head><body><script>var a = 1;</script></body></html>";
+		// script-src allows unsafe-inline, style-src does not
+		String result = injectCspNonceIntoTags(showDoc, input, "linkNonce", false, true);
+		// Link tag SHOULD get nonce (style-src does not allow unsafe-inline)
+		assertTrue(result.contains("nonce=\"linkNonce\""), "Link stylesheet tag should get nonce when style-src does not allow unsafe-inline");
+		// Script tag should NOT get nonce (script-src allows unsafe-inline)
+		assertFalse(result.contains("<script nonce=\"linkNonce\">"), "Script tag should not get nonce when script-src allows unsafe-inline");
 	}
 }

--- a/src/test/java/sk/iway/iwcm/CspNonceTest.java
+++ b/src/test/java/sk/iway/iwcm/CspNonceTest.java
@@ -1,0 +1,315 @@
+package sk.iway.iwcm;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+import sk.iway.iwcm.doc.ShowDoc;
+import sk.iway.iwcm.test.BaseWebjetTest;
+
+/**
+ * JUnit tests for CSP (Content-Security-Policy) nonce functionality.
+ * Tests nonce generation, placeholder replacement, and script tag injection.
+ */
+class CspNonceTest extends BaseWebjetTest {
+
+	@BeforeAll
+	public static void initJpa() {
+		Constants.setString("jpaAddPackages", "");
+		DBPool.getInstance();
+		DBPool.jpaInitialize();
+	}
+
+	@BeforeEach
+	public void setUp() {
+		// Reset the request context for each test
+		SetCharacterEncodingFilter.unRegisterDataContext();
+		Constants.setString("contentSecurityPolicy", "");
+	}
+
+	// ==================== RequestBean Tests ====================
+
+	@Test
+	void testRequestBeanCspNonceDefaultNull() {
+		RequestBean bean = new RequestBean();
+		assertNull(bean.getCspNonce(), "Default cspNonce should be null");
+	}
+
+	@Test
+	void testRequestBeanCspNonceSetAndGet() {
+		RequestBean bean = new RequestBean();
+		bean.setCspNonce("abc123test");
+		assertEquals("abc123test", bean.getCspNonce(), "Should return the set nonce value");
+	}
+
+	@Test
+	void testRequestBeanCspNonceEmptyString() {
+		RequestBean bean = new RequestBean();
+		bean.setCspNonce("");
+		assertEquals("", bean.getCspNonce(), "Should allow empty string");
+	}
+
+	// ==================== SetCharacterEncodingFilter Tests ====================
+
+	@Test
+	void testGenerateCspNonceWhenNoPlaceholder() {
+		Constants.setString("contentSecurityPolicy", "default-src 'self'; script-src 'self'");
+		HttpSession mockSession = mock(HttpSession.class);
+		when(mockSession.getId()).thenReturn("test-session-id");
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+		when(mockRequest.getSession()).thenReturn(mockSession);
+		SetCharacterEncodingFilter.registerDataContext(mockRequest);
+		RequestBean bean = SetCharacterEncodingFilter.getCurrentRequestBean();
+		assertNotNull(bean, "RequestBean should not be null");
+		assertNull(bean.getCspNonce(), "CSP nonce should be null when contentSecurityPolicy has no {nonce} placeholder");
+	}
+
+	@Test
+	void testGenerateCspNonceWhenPlaceholderPresent() {
+		Constants.setString("contentSecurityPolicy", "default-src 'self'; script-src 'self' {nonce}");
+		HttpSession mockSession = mock(HttpSession.class);
+		when(mockSession.getId()).thenReturn("test-session-id");
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+		when(mockRequest.getSession()).thenReturn(mockSession);
+		SetCharacterEncodingFilter.registerDataContext(mockRequest);
+		RequestBean bean = SetCharacterEncodingFilter.getCurrentRequestBean();
+		assertNotNull(bean, "RequestBean should not be null");
+		assertNotNull(bean.getCspNonce(), "CSP nonce should be generated when contentSecurityPolicy contains {nonce}");
+		assertTrue(bean.getCspNonce().length() > 0, "CSP nonce should not be empty");
+	}
+
+	@Test
+	void testGenerateCspNonceUniqueness() {
+		Constants.setString("contentSecurityPolicy", "default-src 'self'; script-src 'self' {nonce}");
+		String nonce1 = null, nonce2 = null, nonce3 = null;
+		HttpSession mockSession = mock(HttpSession.class);
+		when(mockSession.getId()).thenReturn("test-session-id");
+
+		// Generate 3 nonces and verify they are all different
+		for (int i = 0; i < 3; i++) {
+			HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+			when(mockRequest.getSession()).thenReturn(mockSession);
+			SetCharacterEncodingFilter.registerDataContext(mockRequest);
+			RequestBean bean = SetCharacterEncodingFilter.getCurrentRequestBean();
+			switch (i) {
+				case 0: nonce1 = bean.getCspNonce(); break;
+				case 1: nonce2 = bean.getCspNonce(); break;
+				case 2: nonce3 = bean.getCspNonce(); break;
+			}
+		}
+
+		assertNotEquals(nonce1, nonce2, "First and second nonces should be different");
+		assertNotEquals(nonce2, nonce3, "Second and third nonces should be different");
+		assertNotEquals(nonce1, nonce3, "First and third nonces should be different");
+	}
+
+	@Test
+	void testGenerateCspNonceBase64Format() {
+		Constants.setString("contentSecurityPolicy", "default-src 'self'; script-src 'self' {nonce}");
+		HttpSession mockSession = mock(HttpSession.class);
+		when(mockSession.getId()).thenReturn("test-session-id");
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+		when(mockRequest.getSession()).thenReturn(mockSession);
+		SetCharacterEncodingFilter.registerDataContext(mockRequest);
+		RequestBean bean = SetCharacterEncodingFilter.getCurrentRequestBean();
+		String nonce = bean.getCspNonce();
+
+		// Base64 without padding contains only A-Z, a-z, 0-9, +, /
+		assertTrue(nonce.matches("^[A-Za-z0-9+/]+$"), "CSP nonce should be valid base64 without padding");
+	}
+
+	// ==================== PathFilter.setHeader() Tests ====================
+
+	@Test
+	void testSetHeaderNoNoncePlaceholderWhenDisabled() {
+		Constants.setBoolean("cspNonceEnabled", false);
+		Constants.setString("contentSecurityPolicy", "default-src 'self'");
+
+		HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+		PathFilter.setHeader(mockResponse, "Content-Security-Policy", "contentSecurityPolicy");
+
+		verify(mockResponse).setHeader(eq("Content-Security-Policy"), eq("default-src 'self'"));
+	}
+
+	@Test
+	void testSetHeaderReplacesNoncePlaceholder() {
+		Constants.setString("contentSecurityPolicy", "default-src 'self'; script-src 'self' {nonce}");
+
+		HttpSession mockSession = mock(HttpSession.class);
+		when(mockSession.getId()).thenReturn("test-session-id");
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+		when(mockRequest.getSession()).thenReturn(mockSession);
+		SetCharacterEncodingFilter.registerDataContext(mockRequest);
+
+		HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+		PathFilter.setHeader(mockResponse, "Content-Security-Policy", "contentSecurityPolicy");
+
+		// Verify the header was set with the nonce replaced
+		verify(mockResponse).setHeader(eq("Content-Security-Policy"), argThat(value ->
+			value.contains("default-src 'self'") &&
+			value.contains("script-src 'self'") &&
+			value.contains(SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce()) &&
+			!value.contains("{nonce}")
+		));
+	}
+
+	@Test
+	void testSetHeaderNoPlaceholderUnchanged() {
+		Constants.setString("contentSecurityPolicy", "default-src 'self'; script-src 'self'");
+
+		HttpSession mockSession = mock(HttpSession.class);
+		when(mockSession.getId()).thenReturn("test-session-id");
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+		when(mockRequest.getSession()).thenReturn(mockSession);
+		SetCharacterEncodingFilter.registerDataContext(mockRequest);
+
+		HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+		PathFilter.setHeader(mockResponse, "Content-Security-Policy", "contentSecurityPolicy");
+
+		verify(mockResponse).setHeader(eq("Content-Security-Policy"), eq("default-src 'self'; script-src 'self'"));
+	}
+
+	@Test
+	void testSetHeaderMultipleNoncePlaceholders() {
+		Constants.setString("contentSecurityPolicy", "script-src 'self' {nonce}; style-src 'self' {nonce}");
+
+		HttpSession mockSession = mock(HttpSession.class);
+		when(mockSession.getId()).thenReturn("test-session-id");
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+		when(mockRequest.getSession()).thenReturn(mockSession);
+		SetCharacterEncodingFilter.registerDataContext(mockRequest);
+
+		HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+		PathFilter.setHeader(mockResponse, "Content-Security-Policy", "contentSecurityPolicy");
+
+		String expectedNonce = SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce();
+		// Use a simpler assertion that just checks the nonce appears twice in the header
+		verify(mockResponse).setHeader(eq("Content-Security-Policy"), argThat(value -> {
+			int count = 0;
+			int idx = 0;
+			while ((idx = value.indexOf(expectedNonce, idx)) != -1) {
+				count++;
+				idx += expectedNonce.length();
+			}
+			return count == 2 && !value.contains("{nonce}");
+		}));
+	}
+
+	@Test
+	void testSetHeaderEmptyConfigReturnsEarly() {
+		Constants.setString("contentSecurityPolicy", "");
+
+		HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+		PathFilter.setHeader(mockResponse, "Content-Security-Policy", "contentSecurityPolicy");
+
+		verify(mockResponse, never()).setHeader(anyString(), anyString());
+	}
+
+	// ==================== ShowDoc.injectCspNonceIntoScripts() Tests ====================
+
+	@Test
+	void testInjectCspNonceIntoScriptsSimpleScript() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><script>console.log('hello');</script></body></html>";
+		String result = injectCspNonceIntoScripts(showDoc, input, "testnonce123");
+
+		assertTrue(result.contains("nonce=\"testnonce123\""), "Nonce should be injected into simple script tag");
+		assertTrue(result.contains("<script nonce=\"testnonce123\">"), "Script tag should have nonce attribute");
+	}
+
+	@Test
+	void testInjectCspNonceIntoScriptsScriptWithAttributes() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><script type=\"text/javascript\" defer>console.log('hello');</script></body></html>";
+		String result = injectCspNonceIntoScripts(showDoc, input, "myNonce");
+
+		assertTrue(result.contains("nonce=\"myNonce\""), "Nonce should be injected into script with attributes");
+		assertTrue(result.contains("type=\"text/javascript\""), "Original attributes should be preserved");
+		assertTrue(result.contains("defer"), "Original defer attribute should be preserved");
+	}
+
+	@Test
+	void testInjectCspNonceIntoScriptsMultipleScripts() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><script>var a = 1;</script><p>text</p><script>var b = 2;</script></body></html>";
+		String result = injectCspNonceIntoScripts(showDoc, input, "abc123");
+
+		int count = result.split("nonce=\"abc123\"").length - 1;
+		assertEquals(2, count, "Nonce should be injected into all script tags");
+	}
+
+	@Test
+	void testInjectCspNonceIntoScriptsAlreadyHasNonce() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><script nonce=\"existing\">console.log('hello');</script></body></html>";
+		String result = injectCspNonceIntoScripts(showDoc, input, "newNonce");
+
+		// Should NOT add another nonce
+		assertEquals(1, result.split("nonce=").length - 1, "Should not duplicate nonce attribute");
+		assertTrue(result.contains("nonce=\"existing\""), "Original nonce should be preserved");
+	}
+
+	@Test
+	void testInjectCspNonceIntoScriptsNoScriptTags() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><p>No scripts here</p></body></html>";
+		String result = injectCspNonceIntoScripts(showDoc, input, "testnonce");
+
+		assertEquals(input, result, "Content without script tags should remain unchanged");
+	}
+
+	@Test
+	void testInjectCspNonceIntoScriptsEmptyContent() {
+		ShowDoc showDoc = new ShowDoc();
+		String result = injectCspNonceIntoScripts(showDoc, "", "testnonce");
+		assertEquals("", result, "Empty content should remain empty");
+	}
+
+	@Test
+	void testInjectCspNonceIntoScriptsNullNonce() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><script>console.log('hello');</script></body></html>";
+		String result = injectCspNonceIntoScripts(showDoc, input, null);
+
+		assertEquals(input, result, "Content should remain unchanged when nonce is null");
+	}
+
+	@Test
+	void testInjectCspNonceIntoScriptsScriptSrcAttribute() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><script src=\"/app.js\" type=\"module\"></script></body></html>";
+		String result = injectCspNonceIntoScripts(showDoc, input, "moduleNonce");
+
+		assertTrue(result.contains("nonce=\"moduleNonce\""), "Nonce should be injected into external script tag");
+		assertTrue(result.contains("src=\"/app.js\""), "Original src attribute should be preserved");
+	}
+
+	@Test
+	void testInjectCspNonceIntoScriptsMixedScripts() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><script src=\"/app.js\"></script><script>var a = 1;</script><script nonce=\"existing\">var b = 2;</script></body></html>";
+		String result = injectCspNonceIntoScripts(showDoc, input, "generatedNonce");
+
+		// First two scripts should get nonce, third should keep existing
+		int nonceCount = result.split("nonce=").length - 1;
+		assertEquals(3, nonceCount, "All script tags should have nonce attribute");
+	}
+
+	// Helper method to access private method via reflection
+	private String injectCspNonceIntoScripts(ShowDoc showDoc, String htmlContent, String nonce) {
+		try {
+			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("injectCspNonceIntoScripts", String.class, String.class);
+			method.setAccessible(true);
+			return (String) method.invoke(showDoc, htmlContent, nonce);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to invoke injectCspNonceIntoScripts", e);
+		}
+	}
+}

--- a/src/test/java/sk/iway/iwcm/CspNonceTest.java
+++ b/src/test/java/sk/iway/iwcm/CspNonceTest.java
@@ -473,7 +473,93 @@ class CspNonceTest extends BaseWebjetTest {
 			"Nonce should be injected into script tag even when showDocMoveStyleToHead is disabled");
 	}
 
-	// Helper method to access private method via reflection
+	@Test
+	void testProcessInlineStylesSimple() throws Exception {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><div style=\"color: red; font-size: 14px;\">Test</div></body></html>";
+		String nonce = "testNonce";
+
+		String result = invokeProcessInlineStyles(showDoc, input, nonce);
+		// Should replace style attribute with data-inline-style and inject CSS
+		assertTrue(result.contains("data-inline-style=\"1\""), "Should replace style with data-inline-style");
+		assertFalse(result.contains(" style=\""), "Should not contain original style attribute");
+		assertTrue(result.contains("[data-inline-style=\"1\"]"), "Should generate CSS rule");
+		assertTrue(result.contains("color: red !important"), "Should include color property with !important");
+		assertTrue(result.contains("font-size: 14px !important"), "Should include font-size property with !important");
+		assertTrue(result.contains("nonce=\"" + nonce + "\""), "Should inject nonce into style tag");
+	}
+
+	@Test
+	void testProcessInlineStylesSVG() throws Exception {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><svg style=\"width: 10px; height: 20px;\"></svg></body></html>";
+		String nonce = "svgNonce";
+
+		String result = invokeProcessInlineStyles(showDoc, input, nonce);
+		// Should handle SVG elements with inline styles
+		assertTrue(result.contains("data-inline-style=\"1\""), "Should replace SVG style with data-inline-style");
+		assertFalse(result.contains(" style=\""), "Should not contain original style attribute");
+		assertTrue(result.contains("width: 10px !important"), "Should include width property with !important");
+		assertTrue(result.contains("height: 20px !important"), "Should include height property with !important");
+	}
+
+	@Test
+	void testProcessInlineStylesMultipleElements() throws Exception {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><div style=\"color: red;\">A</div><span style=\"color: blue;\">B</span></body></html>";
+		String nonce = "multiNonce";
+
+		String result = invokeProcessInlineStyles(showDoc, input, nonce);
+		// Should handle multiple elements with different counters
+		assertTrue(result.contains("data-inline-style=\"1\""), "First element should have counter 1");
+		assertTrue(result.contains("data-inline-style=\"2\""), "Second element should have counter 2");
+		assertFalse(result.contains(" style=\""), "Should not contain original style attributes");
+		assertTrue(result.contains("[data-inline-style=\"1\"]"), "Should generate CSS rule for counter 1");
+		assertTrue(result.contains("[data-inline-style=\"2\"]"), "Should generate CSS rule for counter 2");
+	}
+
+	@Test
+	void testProcessInlineEventHandlersSimple() throws Exception {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><button onclick=\"clicked()\">Click</button></body></html>";
+		String nonce = "eventNonce";
+
+		String result = invokeProcessInlineEventHandlers(showDoc, input, nonce);
+		// Should replace onclick with data-inline-onclick and inject JavaScript
+		assertTrue(result.contains("data-inline-onclick=\"1\""), "Should replace onclick with data-inline-onclick");
+		assertFalse(result.contains(" onclick=\""), "Should not contain original onclick attribute");
+		assertTrue(result.contains("document.querySelectorAll('[data-inline-onclick=\"1\"]')"), "Should generate JavaScript selector");
+		assertTrue(result.contains("el.onclick = function(event) {clicked();};"), "Should generate function wrapper");
+		assertTrue(result.contains("nonce=\"" + nonce + "\""), "Should inject nonce into script tag");
+	}
+
+	@Test
+	void testProcessInlineEventHandlersMultipleTypes() throws Exception {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><button onclick=\"clicked()\" onmouseover=\"hovered()\">Click</button></body></html>";
+		String nonce = "multiEventNonce";
+
+		String result = invokeProcessInlineEventHandlers(showDoc, input, nonce);
+		// Should handle multiple event handlers with separate counters
+		assertTrue(result.contains("data-inline-onclick=\"1\""), "onclick should have counter 1");
+		assertTrue(result.contains("data-inline-onmouseover=\"1\""), "onmouseover should have counter 1 (separate)");
+		assertFalse(result.contains(" onclick=\""), "Should not contain original onclick");
+		assertFalse(result.contains(" onmouseover=\""), "Should not contain original onmouseover");
+	}
+
+	@Test
+	void testProcessInlineEventHandlersFunctionWrapperPreservesThis() throws Exception {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><body><button onclick=\"this.style.display='none'\">Click</button></body></html>";
+		String nonce = "thisNonce";
+
+		String result = invokeProcessInlineEventHandlers(showDoc, input, nonce);
+		// Should wrap handler in function to preserve 'this'
+		assertTrue(result.contains("el.onclick = function(event) {this.style.display='none';};"),
+			"Should preserve 'this' in function wrapper");
+	}
+
+	// Helper methods
 	private String injectCspNonceIntoTags(ShowDoc showDoc, String htmlContent, String nonce) {
 		try {
 			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("injectCspNonceIntoTags", String.class, String.class);
@@ -481,6 +567,26 @@ class CspNonceTest extends BaseWebjetTest {
 			return (String) method.invoke(showDoc, htmlContent, nonce);
 		} catch (Exception e) {
 			throw new RuntimeException("Failed to invoke injectCspNonceIntoTags", e);
+		}
+	}
+
+	private String invokeProcessInlineStyles(ShowDoc showDoc, String htmlContent, String nonce) {
+		try {
+			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("processInlineStyles", String.class, String.class);
+			method.setAccessible(true);
+			return (String) method.invoke(showDoc, htmlContent, nonce);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to invoke processInlineStyles", e);
+		}
+	}
+
+	private String invokeProcessInlineEventHandlers(ShowDoc showDoc, String htmlContent, String nonce) {
+		try {
+			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("processInlineEventHandlers", String.class, String.class);
+			method.setAccessible(true);
+			return (String) method.invoke(showDoc, htmlContent, nonce);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to invoke processInlineEventHandlers", e);
 		}
 	}
 }

--- a/src/test/java/sk/iway/iwcm/CspNonceTest.java
+++ b/src/test/java/sk/iway/iwcm/CspNonceTest.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 import sk.iway.iwcm.doc.ShowDoc;
+import sk.iway.iwcm.doc.showdoc.ContentCapturingResponseWrapper;
 import sk.iway.iwcm.test.BaseWebjetTest;
 
 /**
@@ -399,6 +400,77 @@ class CspNonceTest extends BaseWebjetTest {
 		assertTrue(result.contains("<script nonce=\"mixedNonce\">"), "Script tag should have nonce");
 		assertTrue(result.contains("<style nonce=\"mixedNonce\">"), "Style tag should have nonce");
 		assertTrue(result.contains("nonce=\"mixedNonce\""), "Link tag should have nonce");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsNoFalsePositiveDataNonce() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<script data-nonce=\"existing\">console.log('test');</script>";
+		String result = injectCspNonceIntoTags(showDoc, input, "newNonce");
+		// Should NOT inject nonce because data-nonce is not the nonce attribute
+		// The false positive check should only match actual nonce attribute
+		assertTrue(result.contains("<script data-nonce=\"existing\" nonce=\"newNonce\">"),
+			"Should inject nonce when only data-nonce exists (not a real nonce attribute)");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsNoFalsePositiveQueryParams() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<script src=\"/app.js?nonce=123\">console.log('test');</script>";
+		String result = injectCspNonceIntoTags(showDoc, input, "realNonce");
+		// Should NOT skip injection just because ?nonce= appears in src attribute
+		assertTrue(result.contains("<script src=\"/app.js?nonce=123\" nonce=\"realNonce\">"),
+			"Should inject nonce when only ?nonce= appears in URL (not a real nonce attribute)");
+	}
+
+	@Test
+	void testShowDocForwardWithCspNonceWhenStyleToHeadDisabled() throws Exception {
+		// Integration test: Verify nonce injection works when showDocMoveStyleToHead is disabled
+		Constants.setBoolean("showDocMoveStyleToHead", false);
+		Constants.setString("contentSecurityPolicy", "default-src 'self'; script-src 'self' {nonce}");
+
+		// Create a mock request with a valid nonce
+		HttpSession mockSession = mock(HttpSession.class);
+		when(mockSession.getId()).thenReturn("test-session-id");
+		HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+		when(mockRequest.getSession()).thenReturn(mockSession);
+		when(mockRequest.getRequestURI()).thenReturn("/test");
+		when(mockRequest.getServletPath()).thenReturn("");
+		when(mockRequest.getContextPath()).thenReturn("");
+		when(mockRequest.getHeader("accept")).thenReturn("text/html");
+		when(mockRequest.getLocale()).thenReturn(java.util.Locale.getDefault());
+		SetCharacterEncodingFilter.registerDataContext(mockRequest);
+
+		// Create response wrapper to capture output
+		ContentCapturingResponseWrapper responseWrapper = mock(ContentCapturingResponseWrapper.class);
+		String testHtml = "<html><head></head><body><script>console.log('test');</script></body></html>";
+		when(responseWrapper.getCapturedContent()).thenReturn(testHtml);
+		when(responseWrapper.getContentType()).thenReturn("text/html;charset=UTF-8");
+		when(responseWrapper.getRedirectLocation()).thenReturn(null);
+		when(responseWrapper.hasError()).thenReturn(false);
+
+		// Create a ShowDoc instance and call forwardWithBodyProcessing
+		ShowDoc showDoc = new ShowDoc();
+		java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("forwardWithBodyProcessing",
+			String.class, HttpServletRequest.class, HttpServletResponse.class);
+		method.setAccessible(true);
+
+		// Capture what gets written to the response
+		HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+		ContentCapturingResponseWrapper actualResponseWrapper = new ContentCapturingResponseWrapper(mockResponse);
+
+		// We can't easily test the full forwarding path without a servlet container,
+		// but we can verify the nonce injection logic is triggered by checking
+		// that the nonce is generated and available
+		RequestBean bean = SetCharacterEncodingFilter.getCurrentRequestBean();
+		assertNotNull(bean.getCspNonce(), "CSP nonce should be generated when contentSecurityPolicy has {nonce}");
+
+		// Verify the nonce is injected into HTML content
+		String cspNonce = bean.getCspNonce();
+		String input = "<html><head></head><body><script>console.log('test');</script></body></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, cspNonce);
+		assertTrue(result.contains("<script nonce=\"" + cspNonce + "\">"),
+			"Nonce should be injected into script tag even when showDocMoveStyleToHead is disabled");
 	}
 
 	// Helper method to access private method via reflection

--- a/src/test/java/sk/iway/iwcm/CspNonceTest.java
+++ b/src/test/java/sk/iway/iwcm/CspNonceTest.java
@@ -460,10 +460,6 @@ class CspNonceTest extends BaseWebjetTest {
 			String.class, HttpServletRequest.class, HttpServletResponse.class);
 		method.setAccessible(true);
 
-		// Capture what gets written to the response
-		HttpServletResponse mockResponse = mock(HttpServletResponse.class);
-		ContentCapturingResponseWrapper actualResponseWrapper = new ContentCapturingResponseWrapper(mockResponse);
-
 		// We can't easily test the full forwarding path without a servlet container,
 		// but we can verify the nonce injection logic is triggered by checking
 		// that the nonce is generated and available
@@ -479,81 +475,81 @@ class CspNonceTest extends BaseWebjetTest {
 	}
 
 	@Test
-	void testProcessInlineStylesSimple() throws Exception {
+	void testProcessInlineStylesSimple() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><div style=\"color: red; font-size: 14px;\">Test</div></body></html>";
 		String nonce = "testNonce";
 
 		String result = invokeProcessInlineStyles(showDoc, input, nonce);
 		// Should replace style attribute with data-inline-style and inject CSS
-		assertTrue(result.contains("data-inline-style=\"1\""), "Should replace style with data-inline-style");
+		assertTrue(result.contains("data-inline-style=\"nonce1\""), "Should replace style with data-inline-style");
 		assertFalse(result.contains(" style=\""), "Should not contain original style attribute");
-		assertTrue(result.contains("[data-inline-style=\"1\"]"), "Should generate CSS rule");
+		assertTrue(result.contains("[data-inline-style=\"nonce1\"]"), "Should generate CSS rule");
 		assertTrue(result.contains("color: red !important"), "Should include color property with !important");
 		assertTrue(result.contains("font-size: 14px !important"), "Should include font-size property with !important");
 		assertTrue(result.contains("nonce=\"" + nonce + "\""), "Should inject nonce into style tag");
 	}
 
 	@Test
-	void testProcessInlineStylesSVG() throws Exception {
+	void testProcessInlineStylesSVG() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><svg style=\"width: 10px; height: 20px;\"></svg></body></html>";
 		String nonce = "svgNonce";
 
 		String result = invokeProcessInlineStyles(showDoc, input, nonce);
 		// Should handle SVG elements with inline styles
-		assertTrue(result.contains("data-inline-style=\"1\""), "Should replace SVG style with data-inline-style");
+		assertTrue(result.contains("data-inline-style=\"nonce1\""), "Should replace SVG style with data-inline-style");
 		assertFalse(result.contains(" style=\""), "Should not contain original style attribute");
 		assertTrue(result.contains("width: 10px !important"), "Should include width property with !important");
 		assertTrue(result.contains("height: 20px !important"), "Should include height property with !important");
 	}
 
 	@Test
-	void testProcessInlineStylesMultipleElements() throws Exception {
+	void testProcessInlineStylesMultipleElements() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><div style=\"color: red;\">A</div><span style=\"color: blue;\">B</span></body></html>";
 		String nonce = "multiNonce";
 
 		String result = invokeProcessInlineStyles(showDoc, input, nonce);
 		// Should handle multiple elements with different counters
-		assertTrue(result.contains("data-inline-style=\"1\""), "First element should have counter 1");
-		assertTrue(result.contains("data-inline-style=\"2\""), "Second element should have counter 2");
+		assertTrue(result.contains("data-inline-style=\"nonce1\""), "First element should have counter 1");
+		assertTrue(result.contains("data-inline-style=\"nonce2\""), "Second element should have counter 2");
 		assertFalse(result.contains(" style=\""), "Should not contain original style attributes");
-		assertTrue(result.contains("[data-inline-style=\"1\"]"), "Should generate CSS rule for counter 1");
-		assertTrue(result.contains("[data-inline-style=\"2\"]"), "Should generate CSS rule for counter 2");
+		assertTrue(result.contains("[data-inline-style=\"nonce1\"]"), "Should generate CSS rule for counter 1");
+		assertTrue(result.contains("[data-inline-style=\"nonce2\"]"), "Should generate CSS rule for counter 2");
 	}
 
 	@Test
-	void testProcessInlineEventHandlersSimple() throws Exception {
+	void testProcessInlineEventHandlersSimple() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><button onclick=\"clicked()\">Click</button></body></html>";
 		String nonce = "eventNonce";
 
 		String result = invokeProcessInlineEventHandlers(showDoc, input, nonce);
 		// Should replace onclick with data-inline-onclick and inject JavaScript
-		assertTrue(result.contains("data-inline-onclick=\"1\""), "Should replace onclick with data-inline-onclick");
+		assertTrue(result.contains("data-inline-onclick=\"nonce1\""), "Should replace onclick with data-inline-onclick");
 		assertFalse(result.contains(" onclick=\""), "Should not contain original onclick attribute");
-		assertTrue(result.contains("document.querySelectorAll('[data-inline-onclick=\"1\"]')"), "Should generate JavaScript selector");
+		assertTrue(result.contains("document.querySelectorAll('[data-inline-onclick=\"nonce1\"]')"), "Should generate JavaScript selector");
 		assertTrue(result.contains("el.onclick = function(event) {clicked();};"), "Should generate function wrapper");
 		assertTrue(result.contains("nonce=\"" + nonce + "\""), "Should inject nonce into script tag");
 	}
 
 	@Test
-	void testProcessInlineEventHandlersMultipleTypes() throws Exception {
+	void testProcessInlineEventHandlersMultipleTypes() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><button onclick=\"clicked()\" onmouseover=\"hovered()\">Click</button></body></html>";
 		String nonce = "multiEventNonce";
 
 		String result = invokeProcessInlineEventHandlers(showDoc, input, nonce);
 		// Should handle multiple event handlers with separate counters
-		assertTrue(result.contains("data-inline-onclick=\"1\""), "onclick should have counter 1");
-		assertTrue(result.contains("data-inline-onmouseover=\"1\""), "onmouseover should have counter 1 (separate)");
+		assertTrue(result.contains("data-inline-onclick=\"nonce1\""), "onclick should have counter 1");
+		assertTrue(result.contains("data-inline-onmouseover=\"nonce1\""), "onmouseover should have counter 1 (separate)");
 		assertFalse(result.contains(" onclick=\""), "Should not contain original onclick");
 		assertFalse(result.contains(" onmouseover=\""), "Should not contain original onmouseover");
 	}
 
 	@Test
-	void testProcessInlineEventHandlersFunctionWrapperPreservesThis() throws Exception {
+	void testProcessInlineEventHandlersFunctionWrapperPreservesThis() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><button onclick=\"this.style.display='none'\">Click</button></body></html>";
 		String nonce = "thisNonce";
@@ -564,114 +560,26 @@ class CspNonceTest extends BaseWebjetTest {
 			"Should preserve 'this' in function wrapper");
 	}
 
-	// Helper methods
-	private String injectCspNonceIntoTags(ShowDoc showDoc, String htmlContent, String nonce) {
-		try {
-			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("injectCspNonceIntoTags", String.class, String.class);
-			method.setAccessible(true);
-			return (String) method.invoke(showDoc, htmlContent, nonce);
-		} catch (Exception e) {
-			throw new RuntimeException("Failed to invoke injectCspNonceIntoTags", e);
-		}
-	}
-
-	private String invokeProcessInlineStyles(ShowDoc showDoc, String htmlContent, String nonce) {
-		try {
-			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("processInlineStyles", String.class, String.class);
-			method.setAccessible(true);
-			return (String) method.invoke(showDoc, htmlContent, nonce);
-		} catch (Exception e) {
-			throw new RuntimeException("Failed to invoke processInlineStyles", e);
-		}
-	}
-
-	private String invokeProcessInlineEventHandlers(ShowDoc showDoc, String htmlContent, String nonce) {
-		try {
-			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("processInlineEventHandlers", String.class, String.class);
-			method.setAccessible(true);
-			return (String) method.invoke(showDoc, htmlContent, nonce);
-		} catch (Exception e) {
-			throw new RuntimeException("Failed to invoke processInlineEventHandlers", e);
-		}
-	}
-
-	// ==================== Helper methods for isUnsafeInlineAllowedInCsp ====================
-
-	private boolean isUnsafeInlineAllowedInCsp(String cspValue) {
-		try {
-			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("isUnsafeInlineAllowedInCsp", String.class);
-			method.setAccessible(true);
-			return (Boolean) method.invoke(null, cspValue);
-		} catch (Exception e) {
-			throw new RuntimeException("Failed to invoke isUnsafeInlineAllowedInCsp", e);
-		}
-	}
-
-	private boolean isDirectiveAllowsUnsafeInline(String cspValue, String directiveName) {
-		try {
-			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("isDirectiveAllowsUnsafeInline", String.class, String.class);
-			method.setAccessible(true);
-			return (Boolean) method.invoke(null, cspValue, directiveName);
-		} catch (Exception e) {
-			throw new RuntimeException("Failed to invoke isDirectiveAllowsUnsafeInline", e);
-		}
-	}
+	// ==================== Helper methods for NonceHelper ====================
 
 	private String injectCspNonceIntoTags(ShowDoc showDoc, String htmlContent, String nonce) {
 		return injectCspNonceIntoTags(showDoc, htmlContent, nonce, true, true);
 	}
 
 	private String injectCspNonceIntoTags(ShowDoc showDoc, String htmlContent, String nonce, boolean injectIntoScripts, boolean injectIntoStyles) {
-		try {
-			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("injectCspNonceIntoTags", String.class, String.class, boolean.class, boolean.class);
-			method.setAccessible(true);
-			return (String) method.invoke(showDoc, htmlContent, nonce, injectIntoScripts, injectIntoStyles);
-		} catch (Exception e) {
-			throw new RuntimeException("Failed to invoke injectCspNonceIntoTags", e);
-		}
+		return sk.iway.iwcm.doc.showdoc.NonceHelper.injectCspNonceIntoTags(htmlContent, nonce, injectIntoScripts, injectIntoStyles);
 	}
 
-	@Test
-	void testIsUnsafeInlineAllowedInCspEmpty() {
-		ShowDoc showDoc = new ShowDoc();
-		assertFalse(isUnsafeInlineAllowedInCsp(null), "Null CSP should return false");
-		assertFalse(isUnsafeInlineAllowedInCsp(""), "Empty CSP should return false");
+	private String invokeProcessInlineStyles(ShowDoc showDoc, String htmlContent, String nonce) {
+		return sk.iway.iwcm.doc.showdoc.NonceHelper.processInlineStyles(htmlContent, nonce);
 	}
 
-	@Test
-	void testIsUnsafeInlineAllowedInCspNoUnsafeInline() {
-		String csp = "default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https:";
-		assertFalse(isUnsafeInlineAllowedInCsp(csp), "CSP without unsafe-inline should return false");
+	private String invokeProcessInlineEventHandlers(ShowDoc showDoc, String htmlContent, String nonce) {
+		return sk.iway.iwcm.doc.showdoc.NonceHelper.processInlineEventHandlers(htmlContent, nonce);
 	}
 
-	@Test
-	void testIsUnsafeInlineAllowedInCspScriptSrcHasUnsafeInline() {
-		String csp = "default-src 'self'; script-src 'self' 'unsafe-inline' {nonce}; style-src 'self'";
-		assertTrue(isUnsafeInlineAllowedInCsp(csp), "CSP with unsafe-inline in script-src should return true");
-	}
-
-	@Test
-	void testIsUnsafeInlineAllowedInCspStyleSrcHasUnsafeInline() {
-		String csp = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'";
-		assertTrue(isUnsafeInlineAllowedInCsp(csp), "CSP with unsafe-inline in style-src should return true");
-	}
-
-	@Test
-	void testIsUnsafeInlineAllowedInCspBothHaveUnsafeInline() {
-		String csp = "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'";
-		assertTrue(isUnsafeInlineAllowedInCsp(csp), "CSP with unsafe-inline in both should return true");
-	}
-
-	@Test
-	void testIsUnsafeInlineAllowedInCspOnlyDefaultSrc() {
-		String csp = "default-src 'self' 'unsafe-inline'; script-src 'self'";
-		assertFalse(isUnsafeInlineAllowedInCsp(csp), "unsafe-inline in default-src only should return false");
-	}
-
-	@Test
-	void testIsUnsafeInlineAllowedInCspLastDirective() {
-		String csp = "default-src 'self'; script-src 'self' {nonce} https:; style-src 'self' {nonce} https: 'unsafe-inline'";
-		assertTrue(isUnsafeInlineAllowedInCsp(csp), "unsafe-inline in last directive should be detected");
+	private boolean isDirectiveAllowsUnsafeInline(String cspValue, String directiveName) {
+		return sk.iway.iwcm.doc.showdoc.NonceHelper.isDirectiveAllowsUnsafeInline(cspValue, directiveName);
 	}
 
 	@Test

--- a/src/test/java/sk/iway/iwcm/CspNonceTest.java
+++ b/src/test/java/sk/iway/iwcm/CspNonceTest.java
@@ -212,13 +212,13 @@ class CspNonceTest extends BaseWebjetTest {
 		verify(mockResponse, never()).setHeader(anyString(), anyString());
 	}
 
-	// ==================== ShowDoc.injectCspNonceIntoScripts() Tests ====================
+	// ==================== ShowDoc.injectCspNonceIntoTags() Tests ====================
 
 	@Test
 	void testInjectCspNonceIntoScriptsSimpleScript() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><script>console.log('hello');</script></body></html>";
-		String result = injectCspNonceIntoScripts(showDoc, input, "testnonce123");
+		String result = injectCspNonceIntoTags(showDoc, input, "testnonce123");
 
 		assertTrue(result.contains("nonce=\"testnonce123\""), "Nonce should be injected into simple script tag");
 		assertTrue(result.contains("<script nonce=\"testnonce123\">"), "Script tag should have nonce attribute");
@@ -228,7 +228,7 @@ class CspNonceTest extends BaseWebjetTest {
 	void testInjectCspNonceIntoScriptsScriptWithAttributes() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><script type=\"text/javascript\" defer>console.log('hello');</script></body></html>";
-		String result = injectCspNonceIntoScripts(showDoc, input, "myNonce");
+		String result = injectCspNonceIntoTags(showDoc, input, "myNonce");
 
 		assertTrue(result.contains("nonce=\"myNonce\""), "Nonce should be injected into script with attributes");
 		assertTrue(result.contains("type=\"text/javascript\""), "Original attributes should be preserved");
@@ -239,7 +239,7 @@ class CspNonceTest extends BaseWebjetTest {
 	void testInjectCspNonceIntoScriptsMultipleScripts() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><script>var a = 1;</script><p>text</p><script>var b = 2;</script></body></html>";
-		String result = injectCspNonceIntoScripts(showDoc, input, "abc123");
+		String result = injectCspNonceIntoTags(showDoc, input, "abc123");
 
 		int count = result.split("nonce=\"abc123\"").length - 1;
 		assertEquals(2, count, "Nonce should be injected into all script tags");
@@ -249,7 +249,7 @@ class CspNonceTest extends BaseWebjetTest {
 	void testInjectCspNonceIntoScriptsAlreadyHasNonce() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><script nonce=\"existing\">console.log('hello');</script></body></html>";
-		String result = injectCspNonceIntoScripts(showDoc, input, "newNonce");
+		String result = injectCspNonceIntoTags(showDoc, input, "newNonce");
 
 		// Should NOT add another nonce
 		assertEquals(1, result.split("nonce=").length - 1, "Should not duplicate nonce attribute");
@@ -260,7 +260,7 @@ class CspNonceTest extends BaseWebjetTest {
 	void testInjectCspNonceIntoScriptsNoScriptTags() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><p>No scripts here</p></body></html>";
-		String result = injectCspNonceIntoScripts(showDoc, input, "testnonce");
+		String result = injectCspNonceIntoTags(showDoc, input, "testnonce");
 
 		assertEquals(input, result, "Content without script tags should remain unchanged");
 	}
@@ -268,7 +268,7 @@ class CspNonceTest extends BaseWebjetTest {
 	@Test
 	void testInjectCspNonceIntoScriptsEmptyContent() {
 		ShowDoc showDoc = new ShowDoc();
-		String result = injectCspNonceIntoScripts(showDoc, "", "testnonce");
+		String result = injectCspNonceIntoTags(showDoc, "", "testnonce");
 		assertEquals("", result, "Empty content should remain empty");
 	}
 
@@ -276,7 +276,7 @@ class CspNonceTest extends BaseWebjetTest {
 	void testInjectCspNonceIntoScriptsNullNonce() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><script>console.log('hello');</script></body></html>";
-		String result = injectCspNonceIntoScripts(showDoc, input, null);
+		String result = injectCspNonceIntoTags(showDoc, input, null);
 
 		assertEquals(input, result, "Content should remain unchanged when nonce is null");
 	}
@@ -285,7 +285,7 @@ class CspNonceTest extends BaseWebjetTest {
 	void testInjectCspNonceIntoScriptsScriptSrcAttribute() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><script src=\"/app.js\" type=\"module\"></script></body></html>";
-		String result = injectCspNonceIntoScripts(showDoc, input, "moduleNonce");
+		String result = injectCspNonceIntoTags(showDoc, input, "moduleNonce");
 
 		assertTrue(result.contains("nonce=\"moduleNonce\""), "Nonce should be injected into external script tag");
 		assertTrue(result.contains("src=\"/app.js\""), "Original src attribute should be preserved");
@@ -295,21 +295,118 @@ class CspNonceTest extends BaseWebjetTest {
 	void testInjectCspNonceIntoScriptsMixedScripts() {
 		ShowDoc showDoc = new ShowDoc();
 		String input = "<html><body><script src=\"/app.js\"></script><script>var a = 1;</script><script nonce=\"existing\">var b = 2;</script></body></html>";
-		String result = injectCspNonceIntoScripts(showDoc, input, "generatedNonce");
+		String result = injectCspNonceIntoTags(showDoc, input, "generatedNonce");
 
 		// First two scripts should get nonce, third should keep existing
 		int nonceCount = result.split("nonce=").length - 1;
 		assertEquals(3, nonceCount, "All script tags should have nonce attribute");
 	}
 
+	// ==================== ShowDoc injectCspNonceIntoTags() Tests for Style and Link Tags ====================
+
+	@Test
+	void testInjectCspNonceIntoTagsSimpleStyle() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><style>body { color: red; }</style></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "styleNonce");
+		assertTrue(result.contains("nonce=\"styleNonce\""), "Nonce should be injected into style tag");
+		assertTrue(result.contains("<style nonce=\"styleNonce\">"), "Style tag should have nonce attribute");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsStyleWithAttributes() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><style type=\"text/css\" media=\"screen\">body { color: red; }</style></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "myStyleNonce");
+		assertTrue(result.contains("nonce=\"myStyleNonce\""), "Nonce should be injected into style with attributes");
+		assertTrue(result.contains("type=\"text/css\""), "Original attributes should be preserved");
+		assertTrue(result.contains("media=\"screen\""), "Original media attribute should be preserved");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsMultipleStyles() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><style>.a { color: red; }</style><style>.b { color: blue; }</style></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "abc");
+		int count = result.split("nonce=\"abc\"").length - 1;
+		assertEquals(2, count, "Nonce should be injected into all style tags");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsStyleAlreadyHasNonce() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><style nonce=\"existing\">body { color: red; }</style></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "newNonce");
+		assertEquals(1, result.split("nonce=").length - 1, "Should not duplicate nonce attribute");
+		assertTrue(result.contains("nonce=\"existing\""), "Original nonce should be preserved");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsLinkStylesheetDoubleQuotes() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><link rel=\"stylesheet\" href=\"/css/main.css\"></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "linkNonce");
+		assertTrue(result.contains("nonce=\"linkNonce\""), "Nonce should be injected into link stylesheet tag");
+		assertTrue(result.contains("rel=\"stylesheet\""), "Original rel attribute should be preserved");
+		assertTrue(result.contains("href=\"/css/main.css\""), "Original href attribute should be preserved");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsLinkStylesheetSingleQuotes() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><link rel='stylesheet' href='/css/main.css'></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "linkNonce");
+		assertTrue(result.contains("nonce=\"linkNonce\""), "Nonce should be injected into link stylesheet tag with single quotes");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsLinkStylesheetNoQuotes() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><link rel=stylesheet href=/css/main.css></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "linkNonce");
+		assertTrue(result.contains("nonce=\"linkNonce\""), "Nonce should be injected into link stylesheet tag without quotes");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsLinkNotStylesheet() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><link rel=\"icon\" href=\"/favicon.ico\"></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "linkNonce");
+		assertEquals(input, result, "Non-stylesheet link tags should not get nonce");
+		assertFalse(result.contains("nonce="), "Should not inject nonce into non-stylesheet link");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsLinkAlreadyHasNonce() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><link rel=\"stylesheet\" href=\"/css/main.css\" nonce=\"existing\"></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "newNonce");
+		int nonceCount = result.split("nonce=").length - 1;
+		assertEquals(1, nonceCount, "Should not duplicate nonce attribute");
+		assertTrue(result.contains("nonce=\"existing\""), "Original nonce should be preserved");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsMixedContent() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><style>.a { color: red; }</style><link rel=\"stylesheet\" href=\"/css/main.css\"></head><body><script>var a = 1;</script></body></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "mixedNonce");
+		// Should inject nonce into all 3 tag types (script, style, link)
+		int nonceCount = result.split("nonce=\"mixedNonce\"").length - 1;
+		assertEquals(3, nonceCount, "Should inject nonce into script, style, and link stylesheet tags");
+		assertTrue(result.contains("<script nonce=\"mixedNonce\">"), "Script tag should have nonce");
+		assertTrue(result.contains("<style nonce=\"mixedNonce\">"), "Style tag should have nonce");
+		assertTrue(result.contains("nonce=\"mixedNonce\""), "Link tag should have nonce");
+	}
+
 	// Helper method to access private method via reflection
-	private String injectCspNonceIntoScripts(ShowDoc showDoc, String htmlContent, String nonce) {
+	private String injectCspNonceIntoTags(ShowDoc showDoc, String htmlContent, String nonce) {
 		try {
-			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("injectCspNonceIntoScripts", String.class, String.class);
+			java.lang.reflect.Method method = ShowDoc.class.getDeclaredMethod("injectCspNonceIntoTags", String.class, String.class);
 			method.setAccessible(true);
 			return (String) method.invoke(showDoc, htmlContent, nonce);
 		} catch (Exception e) {
-			throw new RuntimeException("Failed to invoke injectCspNonceIntoScripts", e);
+			throw new RuntimeException("Failed to invoke injectCspNonceIntoTags", e);
 		}
 	}
 }

--- a/src/test/java/sk/iway/iwcm/CspNonceTest.java
+++ b/src/test/java/sk/iway/iwcm/CspNonceTest.java
@@ -149,14 +149,15 @@ class CspNonceTest extends BaseWebjetTest {
 		when(mockRequest.getSession()).thenReturn(mockSession);
 		SetCharacterEncodingFilter.registerDataContext(mockRequest);
 
+		String expectedNonce = SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce();
 		HttpServletResponse mockResponse = mock(HttpServletResponse.class);
 		PathFilter.setHeader(mockResponse, "Content-Security-Policy", "contentSecurityPolicy");
 
-		// Verify the header was set with the nonce replaced
+		// Verify the header was set with the nonce replaced by 'nonce-<value>' (CSP source expression format)
 		verify(mockResponse).setHeader(eq("Content-Security-Policy"), argThat(value ->
 			value.contains("default-src 'self'") &&
 			value.contains("script-src 'self'") &&
-			value.contains(SetCharacterEncodingFilter.getCurrentRequestBean().getCspNonce()) &&
+			value.contains("'nonce-" + expectedNonce + "'") &&
 			!value.contains("{nonce}")
 		));
 	}

--- a/src/test/java/sk/iway/iwcm/CspNonceTest.java
+++ b/src/test/java/sk/iway/iwcm/CspNonceTest.java
@@ -653,4 +653,93 @@ class CspNonceTest extends BaseWebjetTest {
 		// Script tag should NOT get nonce (script-src allows unsafe-inline)
 		assertFalse(result.contains("<script nonce=\"linkNonce\">"), "Script tag should not get nonce when script-src allows unsafe-inline");
 	}
+
+	// ==================== Edge Cases: Self-closing and explicit closing tags ====================
+
+	@Test
+	void testInjectCspNonceIntoTagsLinkSelfClosingSlash() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><link rel=\"stylesheet\" type=\"text/css\" href=\"/css/main.css\" /></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "linkNonce");
+		assertTrue(result.contains("nonce=\"linkNonce\""), "Nonce should be injected into self-closing link tag (with />)");
+		assertTrue(result.contains("href=\"/css/main.css\""), "Original href attribute should be preserved");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsLinkExplicitClosingTag() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><link rel=\"stylesheet\" type=\"text/css\" href=\"/css/main.css\"></link></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "linkNonce");
+		assertTrue(result.contains("nonce=\"linkNonce\""), "Nonce should be injected into link tag with explicit closing tag (</link>)");
+		assertTrue(result.contains("href=\"/css/main.css\""), "Original href attribute should be preserved");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsLinkSelfClosingWithSpace() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><link rel=\"stylesheet\" type=\"text/css\" href=\"/css/main.css\" > </head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "linkNonce");
+		assertTrue(result.contains("nonce=\"linkNonce\""), "Nonce should be injected into link tag with space before >");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsScriptWithSrcExplicitClosing() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><script src=\"https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js\"></script></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "scriptNonce");
+		assertTrue(result.contains("nonce=\"scriptNonce\""), "Nonce should be injected into script tag with src and explicit closing tag");
+		assertTrue(result.contains("src=\"https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js\""), "Original src attribute should be preserved");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsScriptWithSrcSelfClosing() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><script src=\"https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js\" /></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "scriptNonce");
+		assertTrue(result.contains("nonce=\"scriptNonce\""), "Nonce should be injected into script tag with src and self-closing />");
+		assertTrue(result.contains("src=\"https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js\""), "Original src attribute should be preserved");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsScriptWithSrcNoClosing() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><script src=\"https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js\"></script></head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "scriptNonce");
+		assertTrue(result.contains("nonce=\"scriptNonce\""), "Nonce should be injected into script tag with src attribute");
+		assertTrue(result.contains("src=\"https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js\""), "Original src attribute should be preserved");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsMixedClosingStyles() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head>"
+				+ "<link rel=\"stylesheet\" href=\"/css/a.css\">"
+				+ "<link rel=\"stylesheet\" href=\"/css/b.css\" />"
+				+ "<link rel=\"stylesheet\" href=\"/css/c.css\"></link>"
+				+ "<script src=\"/js/x.js\"></script>"
+				+ "<script src=\"/js/y.js\" />"
+				+ "</head></html>";
+		String result = injectCspNonceIntoTags(showDoc, input, "mixedNonce");
+		// Should inject nonce into all 5 tags
+		int nonceCount = result.split("nonce=\"mixedNonce\"").length - 1;
+		assertEquals(5, nonceCount, "Should inject nonce into all 5 tags with different closing styles");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsLinkSelfClosingNoNonceWhenUnsafeInline() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><link rel=\"stylesheet\" href=\"/css/main.css\" /></head></html>";
+		// style-src allows unsafe-inline, so no nonce injection into style/link tags
+		String result = injectCspNonceIntoTags(showDoc, input, "linkNonce", true, false);
+		assertFalse(result.contains("nonce=\"linkNonce\""), "Self-closing link tag should not get nonce when style-src allows unsafe-inline");
+	}
+
+	@Test
+	void testInjectCspNonceIntoTagsScriptSelfClosingNoNonceWhenUnsafeInline() {
+		ShowDoc showDoc = new ShowDoc();
+		String input = "<html><head><script src=\"/app.js\" /></head></html>";
+		// script-src allows unsafe-inline, so no nonce injection into script tags
+		String result = injectCspNonceIntoTags(showDoc, input, "scriptNonce", false, true);
+		assertFalse(result.contains("nonce=\"scriptNonce\""), "Self-closing script tag should not get nonce when script-src allows unsafe-inline");
+	}
 }

--- a/src/test/java/sk/iway/iwcm/CspNonceTest.java
+++ b/src/test/java/sk/iway/iwcm/CspNonceTest.java
@@ -21,14 +21,14 @@ import sk.iway.iwcm.test.BaseWebjetTest;
 class CspNonceTest extends BaseWebjetTest {
 
 	@BeforeAll
-	public static void initJpa() {
+	static void initJpa() {
 		Constants.setString("jpaAddPackages", "");
 		DBPool.getInstance();
 		DBPool.jpaInitialize();
 	}
 
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 		// Reset the request context for each test
 		SetCharacterEncodingFilter.unRegisterDataContext();
 		Constants.setString("contentSecurityPolicy", "");
@@ -82,7 +82,7 @@ class CspNonceTest extends BaseWebjetTest {
 		RequestBean bean = SetCharacterEncodingFilter.getCurrentRequestBean();
 		assertNotNull(bean, "RequestBean should not be null");
 		assertNotNull(bean.getCspNonce(), "CSP nonce should be generated when contentSecurityPolicy contains {nonce}");
-		assertTrue(bean.getCspNonce().length() > 0, "CSP nonce should not be empty");
+		assertFalse(bean.getCspNonce().isEmpty(), "CSP nonce should not be empty");
 	}
 
 	@Test
@@ -102,6 +102,7 @@ class CspNonceTest extends BaseWebjetTest {
 				case 0: nonce1 = bean.getCspNonce(); break;
 				case 1: nonce2 = bean.getCspNonce(); break;
 				case 2: nonce3 = bean.getCspNonce(); break;
+				default: break;
 			}
 		}
 
@@ -135,7 +136,7 @@ class CspNonceTest extends BaseWebjetTest {
 		HttpServletResponse mockResponse = mock(HttpServletResponse.class);
 		PathFilter.setHeader(mockResponse, "Content-Security-Policy", "contentSecurityPolicy");
 
-		verify(mockResponse).setHeader(eq("Content-Security-Policy"), eq("default-src 'self'"));
+		verify(mockResponse).setHeader("Content-Security-Policy", "default-src 'self'");
 	}
 
 	@Test
@@ -173,7 +174,7 @@ class CspNonceTest extends BaseWebjetTest {
 		HttpServletResponse mockResponse = mock(HttpServletResponse.class);
 		PathFilter.setHeader(mockResponse, "Content-Security-Policy", "contentSecurityPolicy");
 
-		verify(mockResponse).setHeader(eq("Content-Security-Policy"), eq("default-src 'self'; script-src 'self'"));
+		verify(mockResponse).setHeader("Content-Security-Policy", "default-src 'self'; script-src 'self'");
 	}
 
 	@Test


### PR DESCRIPTION
Bezpečnosť - pridať podporu generovania `nonce` pre `Content-Security-Policy` hlavičku, viď napr. https://medium.com/@ooutofmind/enhancing-web-security-implementing-csp-nonce-mechanism-with-spring-cloud-gateway-a5f206d69aee.