### PR TITLE
hotfix/58573-bug:-uprava-stranky-s-buducim-datumom-publikovania

### DIFF
--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -4,7 +4,7 @@
 
 > Opravná verzia pôvodnej verzie 2026.0.
 
-- Web stránky - opravená úprava stránky s budúcim dátumom publikovania. Zrušené plánované verzie sú v histórii zobrazené preškrtnutým písmom a nie je možné ich zmazať (#58573).
+- Web stránky - zrušené [plánované verzie](redactor/webpages/history.md) sú v histórii zobrazené preškrtnutým písmom a nie je možné ich zmazať (#58573).
 - Archív súborov - upravená úloha na pozadí pre publikovanie súborov - z dôvodu práv sa nevykonáva na verejnom uzle (#246).
 - Úlohy na pozadí - pridaná možnosť spustiť [úlohu na pozadí](admin/settings/cronjob/README.md) len na uzloch v plnej konfigurácii alebo na verejných uzloch (#246).
 - Generátor primárnych kľúčov - doplnená automatická oprava mien tabuliek a názvov stĺpca s primárnou hodnotou (#246).

--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -4,6 +4,8 @@
 
 > Opravná verzia pôvodnej verzie 2026.0.
 
+- Web stránky - opravená úprava stránky s budúcim dátumom publikovania. Zrušené plánované verzie sú v histórii zobrazené preškrtnutým písmom a nie je možné ich zmazať (#58573).
+
 ## 2026.0.25
 
 > Opravná verzia pôvodnej verzie 2026.0.

--- a/docs/sk/redactor/webpages/history.md
+++ b/docs/sk/redactor/webpages/history.md
@@ -2,7 +2,7 @@
 
 V karte História sa zobrazujú publikované historické verzie web stránky a **aktuálne rozpracované (ešte nepublikované) verzie**. Pri publikovaní rozpracovanej verzie sa z histórie zmažú dočasné/pracovné verzie stránky a v histórii sa ponechá publikovaná verzia.
 
-Plánované verzie (budúce) majú v stĺpci **Bude publikované** zobrazený dátum, kedy daná verzie bude/bola publikovaná. Ak máte naplánovanú stránku na publikovanie a chcete ju zrušiť stačí ju zmazať. Ak uložíte novú verziu stránky s rovnakým dátumom publikovania ako už existujúca naplánovaná verzia, pôvodná naplánovaná verzia sa automaticky zruší. Zrušené (nepublikovateľné) verzie majú dátum v stĺpci **Bude publikované** zobrazený preškrtnutým písmom.
+Plánované verzie majú v stĺpci **Bude publikované** zobrazený dátum, kedy daná verzie bude/bola publikovaná. Ak máte naplánovanú stránku na publikovanie a chcete ju zrušiť stačí ju zmazať. Zmazať ide len stránky plánované na publikovanie v budúcnosti. Ak uložíte novú verziu stránky s rovnakým dátumom publikovania ako už existujúca naplánovaná verzia, pôvodne naplánovanej verzia sa publikovanie zruší. Takéto verzie majú dátum v stĺpci **Bude publikované** zobrazený preškrtnutým písmom.
 
 Stránky, ktoré majú nastavenú možnosť **Odverejniť stránku po tomto dátume** zobrazujú dátum v stĺpci **Bude vypnuté**. V danom čase sa vypne verejné zobrazovanie web stránky (stránka nebude pre verejnosť dostupná). Ak potrebujete vypnutie stránky zrušiť je potrebné upraviť danú verziu a plánované vypnutie zrušiť jej znova uložením.
 

--- a/docs/sk/redactor/webpages/history.md
+++ b/docs/sk/redactor/webpages/history.md
@@ -2,7 +2,7 @@
 
 V karte História sa zobrazujú publikované historické verzie web stránky a **aktuálne rozpracované (ešte nepublikované) verzie**. Pri publikovaní rozpracovanej verzie sa z histórie zmažú dočasné/pracovné verzie stránky a v histórii sa ponechá publikovaná verzia.
 
-Plánované verzie (budúce) majú v stĺpci **Bude publikované** zobrazený dátum, kedy daná verzie bude/bola publikovaná. Ak máte naplánovanú stránku na publikovanie a chcete ju zrušiť stačí ju zmazať.
+Plánované verzie (budúce) majú v stĺpci **Bude publikované** zobrazený dátum, kedy daná verzie bude/bola publikovaná. Ak máte naplánovanú stránku na publikovanie a chcete ju zrušiť stačí ju zmazať. Ak uložíte novú verziu stránky s rovnakým dátumom publikovania ako už existujúca naplánovaná verzia, pôvodná naplánovaná verzia sa automaticky zruší. Zrušené (nepublikovateľné) verzie majú dátum v stĺpci **Bude publikované** zobrazený preškrtnutým písmom.
 
 Stránky, ktoré majú nastavenú možnosť **Odverejniť stránku po tomto dátume** zobrazujú dátum v stĺpci **Bude vypnuté**. V danom čase sa vypne verejné zobrazovanie web stránky (stránka nebude pre verejnosť dostupná). Ak potrebujete vypnutie stránky zrušiť je potrebné upraviť danú verziu a plánované vypnutie zrušiť jej znova uložením.
 
@@ -17,6 +17,6 @@ V prípade schvaľovania/zamietnutia stránky sa zobrazuje aj meno používateľ
 Zvolením riadku a kliknutím na ikonu je možné vykonať akcie:
 
 - ![](history-btn-edit.png ":no-zoom") - Editovať stránku - zvolená verzia sa načíta z histórie do editora. Umožňuje Vám nanovo publikovať staršiu verziu stránky.
-- ![](history-btn-remove.png ":no-zoom") - Zmazať - zmaže stránku z histórie, je možné použiť len na stránky s naplánovaným publikovaním (majú vyplnený dátum v **Bude publikované**).
+- ![](history-btn-remove.png ":no-zoom") - Zmazať - zmaže stránku z histórie, je možné použiť len na stránky s naplánovaným publikovaním (majú vyplnený dátum v **Bude publikované** a sú označené ako publikovateľné).
 - ![](history-btn-preview.png ":no-zoom") - Zobraziť stránku - zobrazí zvolenú web stránku z histórie. Upozorňujeme, že v histórii sa ukladá text stránky, ak dôjde k zmene šablóny (napr. v pätičke stránky) toto nebude reflektované pri zobrazení.
 - ![](history-btn-compare.png ":no-zoom") - Porovnať stránku - zobrazí sa vám nové okno, ktoré je rozdelené na dve časti s obsahom aktuálnej a novej verzie stránky. Obe časti sú vzájomne synchronizované, takže sa vám pri prezeraní obsahu pohybujú súčasne. V okne porovnania máte tiež možnosť zvýrazniť zmeny uloženej verzie z histórie voči aktuálnej publikovanej verzii web stránky. Táto operácia sa vykoná po kliknutí na odkaz "Zvýrazniť rozdiely" v hornej časti okna.

--- a/src/main/java/sk/iway/iwcm/doc/DocHistoryRepository.java
+++ b/src/main/java/sk/iway/iwcm/doc/DocHistoryRepository.java
@@ -40,7 +40,7 @@ public interface DocHistoryRepository extends JpaRepository<DocHistory, Long>, J
     //
     @Transactional
     @Modifying
-    @Query(value = "UPDATE DocHistory SET actual = :actual, awaitingApprove = :awaitingApprove, syncStatus = 1 WHERE id IN :historyIds")
+    @Query(value = "UPDATE DocHistory SET actual = :actual, awaitingApprove = :awaitingApprove WHERE id IN :historyIds")
     public void updateActualHistory(@Param("actual")boolean actual, @Param("awaitingApprove")String awaitingApprove, @Param("historyIds")List<Integer> historyIds);
 
     @Transactional
@@ -76,8 +76,8 @@ public interface DocHistoryRepository extends JpaRepository<DocHistory, Long>, J
 
     @Transactional
     @Modifying
-    @Query(value = "UPDATE DocHistory dh SET dh.actual = :actual, dh.syncStatus = 1 WHERE dh.id IN :historyIds")
-    public void updateActualAndSyncStatus(@Param("actual")boolean actual, @Param("historyIds")int[] historyIds);
+    @Query(value = "UPDATE DocHistory dh SET dh.actual = :actual WHERE dh.id IN :historyIds")
+    public void updateActual(@Param("actual")boolean actual, @Param("historyIds")int[] historyIds);
 
     @Transactional
     @Modifying

--- a/src/main/java/sk/iway/iwcm/doc/DocHistoryRepository.java
+++ b/src/main/java/sk/iway/iwcm/doc/DocHistoryRepository.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 @Repository
 public interface DocHistoryRepository extends JpaRepository<DocHistory, Long>, JpaSpecificationExecutor<DocHistory> {
 
+    List<DocHistory> findByDocIdAndPublishStartDate(Integer docId, Date publishStartDate);
     List<DocHistory> findByDocIdAndPublishStartDateBetween(Integer docId, Date publishStartDateFrom, Date publishStartDateTo);
 
     //

--- a/src/main/java/sk/iway/iwcm/doc/DocHistoryRepository.java
+++ b/src/main/java/sk/iway/iwcm/doc/DocHistoryRepository.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 @Repository
 public interface DocHistoryRepository extends JpaRepository<DocHistory, Long>, JpaSpecificationExecutor<DocHistory> {
 
-    List<DocHistory> findByDocIdAndPublishStartDate(Integer docId, Date publishStartDate);
     List<DocHistory> findByDocIdAndPublishStartDateBetween(Integer docId, Date publishStartDateFrom, Date publishStartDateTo);
 
     //

--- a/src/main/java/sk/iway/iwcm/doc/DocHistoryRepository.java
+++ b/src/main/java/sk/iway/iwcm/doc/DocHistoryRepository.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 @Repository
 public interface DocHistoryRepository extends JpaRepository<DocHistory, Long>, JpaSpecificationExecutor<DocHistory> {
 
-    List<DocHistory> findByDocIdAndPublishStartDate(Integer docId, Date publishStartDate);
+    List<DocHistory> findByDocIdAndPublishStartDateBetween(Integer docId, Date publishStartDateFrom, Date publishStartDateTo);
 
     //
     @Query(value = "SELECT history_id FROM documents_history WHERE doc_id = ?1 AND history_id < ?2 AND publicable = ?3 AND author_id = ?4", nativeQuery=true)

--- a/src/main/java/sk/iway/iwcm/doc/DocPublishService.java
+++ b/src/main/java/sk/iway/iwcm/doc/DocPublishService.java
@@ -111,14 +111,14 @@ public class DocPublishService {
 			return;
 		}
 
-		dhr.updateActualAndSyncStatus(false, Tools.getTokensInt(sk.iway.iwcm.DB.getOnlyNumbersIn(historyIds), ","));
+		dhr.updateActual(false, Tools.getTokensInt(sk.iway.iwcm.DB.getOnlyNumbersIn(historyIds), ","));
 
 		//updatni zaznam v history, zrus publicable a nastav actual
 		dhr.updatePublicableAndActual(false, true, docDetails.getAuthorId(), true, docDetails.getHistoryId());
 
 		Logger.println(this,"pForm.getPublishStart()=" + docDetails.getPublishStart());
 
-		///Now is available
+		//Now is available
 		docDetails.setAvailable(true);
 		docDetails.setPerexGroupString( docDetails.getPerexGroupIdsString(true) );
 

--- a/src/main/java/sk/iway/iwcm/doc/HistoryDB.java
+++ b/src/main/java/sk/iway/iwcm/doc/HistoryDB.java
@@ -127,6 +127,7 @@ public class HistoryDB extends DB
 					doc.setHistoryApproveDate(getDbDateTime(rs, "approve_date", serverName));
 					doc.setHistoryDisapprovedBy(rs.getInt("disapproved_by"));
 
+					doc.setPublicable(rs.getBoolean("publicable"));
 					if (rs.getBoolean("publicable"))
 					{
 						//zistuje ci stranka bude niekedy publikovana alebo uz nie
@@ -247,6 +248,7 @@ public class HistoryDB extends DB
 					doc.setHistoryActual(rs.getBoolean("actual"));
 					doc.setHistoryApproveDate(getDbDateTime(rs, "approve_date", serverName));
 
+					doc.setPublicable(rs.getBoolean("publicable"));
 					if (rs.getBoolean("publicable") || rs.getBoolean("publish_after_start")) //zistuje ci stranka bude
 																// niekedy publikovana alebo uz
 																// nie

--- a/src/main/java/sk/iway/iwcm/doc/HistoryDB.java
+++ b/src/main/java/sk/iway/iwcm/doc/HistoryDB.java
@@ -192,7 +192,7 @@ public class HistoryDB extends DB
 					doc.setFieldT(DB.getDbString(rs, "field_t"));
 
 					doc.setRequireSsl(rs.getBoolean("require_ssl"));
-
+					doc.setSyncStatus(rs.getInt("sync_status"));
 
 					if ((doc.getHistoryApprovedBy()>0 && doc.getAuthorId()!=doc.getHistoryApprovedBy()) || doc.getHistoryDisapprovedBy()>0) {
 						if (doc.getHistoryApprovedBy()>0)
@@ -257,6 +257,7 @@ public class HistoryDB extends DB
 					{
 					  doc.setPublishStartStringExtra("&nbsp;");
 					}
+					doc.setSyncStatus(rs.getInt("sync_status"));
 
 					if (onlyNew && doc.isHistoryActual())
 					{

--- a/src/main/java/sk/iway/iwcm/editor/rest/DocHistoryDto.java
+++ b/src/main/java/sk/iway/iwcm/editor/rest/DocHistoryDto.java
@@ -49,6 +49,9 @@ public class DocHistoryDto {
     @DataTableColumn(inputType = DataTableColumnType.HIDDEN)
     private Boolean publicable;
 
+    @DataTableColumn(inputType = DataTableColumnType.HIDDEN)
+    private int syncStatus;
+
     private boolean historyActual;
     private boolean disableAfterEnd;
     private BaseEditorFields editorFields;

--- a/src/main/java/sk/iway/iwcm/editor/rest/DocHistoryDto.java
+++ b/src/main/java/sk/iway/iwcm/editor/rest/DocHistoryDto.java
@@ -46,6 +46,9 @@ public class DocHistoryDto {
     @DataTableColumn(inputType = DataTableColumnType.DATETIME, title="editor.dateEnd")
 	private Date publishEndDate;
 
+    @DataTableColumn(inputType = DataTableColumnType.HIDDEN)
+    private Boolean publicable;
+
     private boolean historyActual;
     private boolean disableAfterEnd;
     private BaseEditorFields editorFields;

--- a/src/main/java/sk/iway/iwcm/editor/rest/DocHistoryDto.java
+++ b/src/main/java/sk/iway/iwcm/editor/rest/DocHistoryDto.java
@@ -21,7 +21,7 @@ public class DocHistoryDto {
     @DataTableColumn(inputType = DataTableColumnType.DATETIME, title = "history.date")
     private Long historySaveDate;
 
-    @DataTableColumn(inputType = DataTableColumnType.DATETIME, title="editor.willBePublishedAt")
+    @DataTableColumn(inputType = DataTableColumnType.DATETIME, title="editor.willBePublishedAt", className = "dt-publish-start-string-extra")
     private Date publishStartStringExtra;
 
     //obsahuje datum depublikovania (ak je nastavene disableAfterEnd)

--- a/src/main/java/sk/iway/iwcm/editor/service/EditorService.java
+++ b/src/main/java/sk/iway/iwcm/editor/service/EditorService.java
@@ -303,7 +303,10 @@ public class EditorService {
 		if (!disableHistory) {
 			// zisti, ci v historii na ten isty datum a cas nema byt nieco vypublikovane
 			if (editedDoc.getPublishStartDate() != null && (editedDoc.getPublishStartDate().getTime()+60000)>Tools.getNow()) {
-				List<DocHistory> waitingForPublish = historyRepo.findByDocIdAndPublishStartDate(editedDoc.getDocId(), editedDoc.getPublishStartDate());
+				Date publishStartDate = editedDoc.getPublishStartDate();
+				Date publishStartDateFrom = new Date(publishStartDate.getTime() - 5000L);
+				Date publishStartDateTo = new Date(publishStartDate.getTime() + 5000L);
+				List<DocHistory> waitingForPublish = historyRepo.findByDocIdAndPublishStartDateBetween(editedDoc.getDocId(), publishStartDateFrom, publishStartDateTo);
 				if (waitingForPublish != null) {
 					for (DocHistory waiting : waitingForPublish) {
 						waiting.setPublicable(false);

--- a/src/main/java/sk/iway/iwcm/editor/service/EditorService.java
+++ b/src/main/java/sk/iway/iwcm/editor/service/EditorService.java
@@ -311,7 +311,9 @@ public class EditorService {
 				if (waitingForPublish != null) {
 					for (DocHistory waiting : waitingForPublish) {
 						waiting.setPublicable(false);
-						waiting.setSyncStatus(1);
+						//by sync_status=2 we know that this record was waiting for publish, but now it is not publicable
+						//checked in web-pages-datatable.js to mark this record with strikethrough date
+						waiting.setSyncStatus(2);
 						historyRepo.save(waiting);
 					}
 				}

--- a/src/main/java/sk/iway/iwcm/editor/service/EditorService.java
+++ b/src/main/java/sk/iway/iwcm/editor/service/EditorService.java
@@ -304,6 +304,7 @@ public class EditorService {
 			// zisti, ci v historii na ten isty datum a cas nema byt nieco vypublikovane
 			if (editedDoc.getPublishStartDate() != null && (editedDoc.getPublishStartDate().getTime()+60000)>Tools.getNow()) {
 				Date publishStartDate = editedDoc.getPublishStartDate();
+				// check if there is any other DocHistory with same publishStartDate (+-5 seconds)
 				Date publishStartDateFrom = new Date(publishStartDate.getTime() - 5000L);
 				Date publishStartDateTo = new Date(publishStartDate.getTime() + 5000L);
 				List<DocHistory> waitingForPublish = historyRepo.findByDocIdAndPublishStartDateBetween(editedDoc.getDocId(), publishStartDateFrom, publishStartDateTo);

--- a/src/main/webapp/admin/v9/src/js/pages/web-pages-list/web-pages-datatable.js
+++ b/src/main/webapp/admin/v9/src/js/pages/web-pages-list/web-pages-datatable.js
@@ -283,7 +283,7 @@ export class WebPagesDatatable {
                         var data = this.data();
                         if (data.publicable === false && data.publishStartStringExtra != null && data.publishStartStringExtra != "") {
                             //only if it is in future
-                            if (Date.now() < data.publishStartStringExtra) {
+                            if (Date.now() < data.publishStartStringExtra || data.syncStatus == 2) {
                                 $(this.node()).addClass('not-publicable');
                             }
                         }

--- a/src/main/webapp/admin/v9/src/js/pages/web-pages-list/web-pages-datatable.js
+++ b/src/main/webapp/admin/v9/src/js/pages/web-pages-list/web-pages-datatable.js
@@ -218,6 +218,7 @@ export class WebPagesDatatable {
                             dt.rows({selected: true}).every( function ( rowIdx, tableLoop, rowLoop ) {
                                 var data = this.data();
                                 if (data.publishStartStringExtra==null) show = false;
+                                if (data.publicable !== true) show = false;
                                 count ++;
                             });
                             //console.log("show=", show, "count=", count);
@@ -275,6 +276,15 @@ export class WebPagesDatatable {
                         'title': window.WJ.translate('groupslist.compare'),
                         'data-toggle': 'tooltip'
                     }
+                });
+
+                historyTable.on( 'draw', function () {
+                    historyTable.rows().every(function() {
+                        var data = this.data();
+                        if (data.publicable === false) {
+                            $(this.node()).addClass('not-publicable');
+                        }
+                    });
                 });
             }
             if (event.detail.conf.id=="DTE_Field_editorFields.groupSchedulerPlannedChanges" ||

--- a/src/main/webapp/admin/v9/src/js/pages/web-pages-list/web-pages-datatable.js
+++ b/src/main/webapp/admin/v9/src/js/pages/web-pages-list/web-pages-datatable.js
@@ -281,8 +281,11 @@ export class WebPagesDatatable {
                 historyTable.on( 'draw', function () {
                     historyTable.rows().every(function() {
                         var data = this.data();
-                        if (data.publicable === false) {
-                            $(this.node()).addClass('not-publicable');
+                        if (data.publicable === false && data.publishStartStringExtra != null && data.publishStartStringExtra != "") {
+                            //only if it is in future
+                            if (Date.now() < data.publishStartStringExtra) {
+                                $(this.node()).addClass('not-publicable');
+                            }
                         }
                     });
                 });

--- a/src/main/webapp/admin/v9/src/scss/3-base/_table.scss
+++ b/src/main/webapp/admin/v9/src/scss/3-base/_table.scss
@@ -1654,6 +1654,13 @@ table.dataTable thead > tr > th.dt-orderable-asc:hover, table.dataTable thead > 
     outline: none;
 }
 
+//history table - not publicable row
+#datatableFieldDTE_Field_editorFields-history tr.not-publicable {
+    td:nth-child(3) {
+        text-decoration: line-through;
+    }
+}
+
 //row reorder
 div.dt-rowReorder-float-parent {
     position: absolute;

--- a/src/main/webapp/admin/v9/src/scss/3-base/_table.scss
+++ b/src/main/webapp/admin/v9/src/scss/3-base/_table.scss
@@ -1656,7 +1656,7 @@ table.dataTable thead > tr > th.dt-orderable-asc:hover, table.dataTable thead > 
 
 //history table - not publicable row
 #datatableFieldDTE_Field_editorFields-history tr.not-publicable {
-    td:nth-child(3) {
+    td.dt-publish-start-string-extra {
         text-decoration: line-through;
     }
 }

--- a/src/test/webapp/tests/webpages/webpage-history.js
+++ b/src/test/webapp/tests/webpages/webpage-history.js
@@ -1,9 +1,13 @@
 Feature('webpages.webpage-history');
 
+const historyTable = '#datatableFieldDTE_Field_editorFields-history';
+const historyWrapper = historyTable + '_wrapper';
+const historyProcessing = historyTable + '_processing';
+
 var folder_name, subfolder_one, subfolder_two, auto_webPage, randomNumber, now,
-     edit_history_webpage = (locate('#datatableFieldDTE_Field_editorFields-history_wrapper').find('.btn.btn-sm.btn-warning.buttons-history-edit')),
-     view_history_webpage = (locate('#datatableFieldDTE_Field_editorFields-history_wrapper').find('.btn.btn-sm.btn-outline-secondary.buttons-history-preview')),
-     compare_history_webpage = (locate('#datatableFieldDTE_Field_editorFields-history_wrapper').find('.btn.btn-sm.btn-outline-secondary.buttons-divider.buttons-history-compare'));
+     edit_history_webpage = (locate(historyWrapper).find('.btn.btn-sm.btn-warning.buttons-history-edit')),
+     view_history_webpage = (locate(historyWrapper).find('.btn.btn-sm.btn-outline-secondary.buttons-history-preview')),
+     compare_history_webpage = (locate(historyWrapper).find('.btn.btn-sm.btn-outline-secondary.buttons-divider.buttons-history-compare'));
 
 Before(({ I, login }) => {
      login('admin');
@@ -20,12 +24,12 @@ Before(({ I, login }) => {
 
 // Nahlad - stara verzia a nova verzia
 function insight(I, version) {
-     I.forceClick(locate('#datatableFieldDTE_Field_editorFields-history>tbody>tr.even').find('.dt-select-td.cell-not-editable'));
+     I.forceClick(locate(historyTable + '>tbody>tr.even').find('.dt-select-td.cell-not-editable'));
 
      if (version === 'old') {
           I.waitForText('1 riadok označený', 10, '.select-item');
      } else if (version === 'new') {
-          I.forceClick(locate('#datatableFieldDTE_Field_editorFields-history>tbody>tr.odd').find('.dt-select-td.cell-not-editable'));
+          I.forceClick(locate(historyTable + '>tbody>tr.odd').find('.dt-select-td.cell-not-editable'));
      }
 
      I.click(view_history_webpage);
@@ -154,14 +158,14 @@ Scenario('Historia webstranok', ({ I, DTE }) => {
      I.say('3.Kontrola historie na zalozke Historia');
      I.toastrClose();
      I.clickCss("#pills-dt-datatableInit-history-tab", null, { position: { x: 0, y: 0 } }); //because after toastr close cursor stays in close button tooltip
-     I.waitForVisible('#datatableFieldDTE_Field_editorFields-history_wrapper');
+     I.waitForVisible(historyWrapper);
 
      // V tabulke vidim 2 zaznamy s dnesnym datumom
      I.say('V tabulke historia vidim 2 zaznamy s dnesnym datumom');
 
-     I.waitForElement(locate('#datatableFieldDTE_Field_editorFields-history>tbody>tr').withText(I.formatDate(now.getTime())), 20);
+     I.waitForElement(locate(historyTable + '>tbody>tr').withText(I.formatDate(now.getTime())), 20);
 
-     I.seeNumberOfVisibleElements(locate('#datatableFieldDTE_Field_editorFields-history>tbody>tr').withText(I.formatDate(now.getTime())), 2);
+     I.seeNumberOfVisibleElements(locate(historyTable + '>tbody>tr').withText(I.formatDate(now.getTime())), 2);
 
      // 2.ZOBRAZ NAHLAD STARSEJ A NOVSEJ WEBSTRANKY
      I.say('Zobrazujem nahlad starsej stranky');
@@ -172,9 +176,9 @@ Scenario('Historia webstranok', ({ I, DTE }) => {
 
      // 3.POROVNANIE NOVSEJ A STARSEJ STRANKY
      I.say('Porovnanie novsej a starsej stranky');
-     I.forceClick(locate('#datatableFieldDTE_Field_editorFields-history>tbody>tr.odd').find('.dt-select-td.cell-not-editable'));
+     I.forceClick(locate(historyTable + '>tbody>tr.odd').find('.dt-select-td.cell-not-editable'));
      I.wait(0.5);
-     I.forceClick(locate('#datatableFieldDTE_Field_editorFields-history>tbody>tr.even').find('.dt-select-td.cell-not-editable'));
+     I.forceClick(locate(historyTable + '>tbody>tr.even').find('.dt-select-td.cell-not-editable'));
      I.click(compare_history_webpage);
      I.switchToNextTab();
 
@@ -260,13 +264,13 @@ Scenario('history from multigroup mapping', ({ I, DT, DTE }) => {
 
      I.switchTo();
      I.clickCss("#pills-dt-datatableInit-history-tab");
-     DT.waitForLoader("#datatableFieldDTE_Field_editorFields-history_processing");
-     I.fillField("#datatableFieldDTE_Field_editorFields-history_wrapper input.filter-input-id", "687");
-     I.clickCss("#datatableFieldDTE_Field_editorFields-history_wrapper button.dt-filtrujem-id");
-     DT.waitForLoader("#datatableFieldDTE_Field_editorFields-history_processing");
+     DT.waitForLoader(historyProcessing);
+     I.fillField(historyWrapper + " input.filter-input-id", "687");
+     I.clickCss(historyWrapper + " button.dt-filtrujem-id");
+     DT.waitForLoader(historyProcessing);
 
-     I.clickCss("#datatableFieldDTE_Field_editorFields-history_wrapper button.buttons-select-all");
-     I.clickCss("#datatableFieldDTE_Field_editorFields-history_wrapper button.buttons-history-edit");
+     I.clickCss(historyWrapper + " button.buttons-select-all");
+     I.clickCss(historyWrapper + " button.buttons-history-edit");
 
      I.waitForElement("#pills-dt-datatableInit-content-tab.nav-link.active", 20);
      I.switchTo(".cke_wysiwyg_frame");
@@ -285,4 +289,73 @@ Scenario('open webpage history from URL', ({ I, DTE }) => {
      I.switchTo();
      DTE.cancel();
      I.dontSeeInCurrentUrl("history=687");
+});
+
+Scenario('not-publicable history row when saving with same future publish date', async ({ I, DT, DTE }) => {
+     const docId = 22956;
+     const delete_history_button = locate(historyWrapper).find('.btn.buttons-history-remove');
+
+     // Set future publish date for the page
+     I.say('Set future publish date for the page');
+     I.amOnPage(`/admin/v9/webpages/web-pages-list/?docid=${docId}`);
+     DTE.waitForEditor();
+
+     const tomorrow = new Date();
+     tomorrow.setDate(tomorrow.getDate() + 1);
+     tomorrow.setHours(12, 0, 0, 0);
+     const publishDateText = I.formatDateTime(tomorrow.getTime());
+
+     await DTE.fillCkeditor("<p>autotest first version future publish</p>");
+     I.clickCss("#pills-dt-datatableInit-perex-tab");
+     DTE.fillField("publishStartDate", publishDateText);
+     I.pressKey("Tab");
+     I.checkOption("#DTE_Field_editorFields-publishAfterStart_0");
+     DTE.save();
+     I.toastrClose();
+
+     // Save again with the same publish date - old version should become not-publicable
+     I.say('Save again with same publish date - old version should become not-publicable');
+     I.click("Test casoveho publikovania", "#datatableInit_wrapper");
+     DTE.waitForEditor();
+     await I.clickIfVisible(".toast-close-button");
+
+     await DTE.fillCkeditor("<p>autotest second version future publish</p>");
+     I.clickCss("#pills-dt-datatableInit-perex-tab");
+     DTE.fillField("publishStartDate", publishDateText);
+     I.pressKey("Tab");
+     I.checkOption("#DTE_Field_editorFields-publishAfterStart_0");
+     DTE.save();
+     I.toastrClose();
+
+     // Open editor and check history tab
+     I.say('Open editor and check history tab for not-publicable row');
+     I.click("Test casoveho publikovania", "#datatableInit_wrapper");
+     DTE.waitForEditor();
+     await I.clickIfVisible(".toast-close-button");
+
+     I.clickCss("#pills-dt-datatableInit-history-tab");
+     DT.waitForLoader(historyProcessing);
+
+     // Verify not-publicable row has line-through styling (not-publicable CSS class)
+     I.seeElement(locate(historyTable + ' tr.not-publicable'));
+
+     // Select the not-publicable row and verify delete button is disabled
+     I.say('Select not-publicable row - delete button should be disabled');
+     I.forceClick(locate(historyTable + ' tr.not-publicable').find('.dt-select-td'));
+     I.waitForText('1 riadok označený', 10, '.select-item');
+     I.seeElement({css: historyWrapper + ' .btn.buttons-history-remove.disabled'});
+
+     DTE.cancel();
+
+     // Cleanup - reset the page to default state without future publish date
+     I.say('Cleanup - reset page to default state');
+     I.amOnPage(`/admin/v9/webpages/web-pages-list/?docid=${docId}`);
+     DTE.waitForEditor();
+     await I.clickIfVisible(".toast-close-button");
+
+     await DTE.fillCkeditor("<p>Test casoveho publikovania stranky ID:" + docId + "</p>");
+     I.clickCss("#pills-dt-datatableInit-perex-tab");
+     DTE.fillField("publishStartDate", "");
+     I.uncheckOption("#DTE_Field_editorFields-publishAfterStart_0");
+     DTE.save();
 });


### PR DESCRIPTION
Mám nahlásený BUG s editáciou stránky v budúcnosti. Čo si ale pamätám, WebJET by pri uložení takejto stránky mal automaticky zmazať tú predchádzajúcu naplánovanú verziu (ak sú naplánované na rovnaký dátum), tiež treba preveriť, prečo stránka v budúcnosti nejde zmazať.