### PR TITLE
WebJETPerformanceProfiler: FIX NPE pri ziskani entity pre interne / sekvencne dotazy ktore nemaju entitu

### DIFF
--- a/src/main/java/sk/iway/iwcm/system/jpa/WebJETPerformanceProfiler.java
+++ b/src/main/java/sk/iway/iwcm/system/jpa/WebJETPerformanceProfiler.java
@@ -55,13 +55,13 @@ public class WebJETPerformanceProfiler extends PerformanceProfiler
 
     public boolean shouldLogProfile(Profile profile)
     {
+        if (shouldLogProfile() == false)
+        {
+            return false;
+        }
         Class<?> domainClass = profile.getDomainClass();
         if (domainClass == null) {
             // sekvencne / interne dotazy (NEXTVAL, DDL, ...) nemaju entitu
-            return false;
-        }
-        if (shouldLogProfile() == false)
-        {
             return false;
         }
         String className = domainClass.getSimpleName();

--- a/src/main/java/sk/iway/iwcm/system/jpa/WebJETPerformanceProfiler.java
+++ b/src/main/java/sk/iway/iwcm/system/jpa/WebJETPerformanceProfiler.java
@@ -55,11 +55,16 @@ public class WebJETPerformanceProfiler extends PerformanceProfiler
 
     public boolean shouldLogProfile(Profile profile)
     {
+        Class<?> domainClass = profile.getDomainClass();
+        if (domainClass == null) {
+            // sekvencne / interne dotazy (NEXTVAL, DDL, ...) nemaju entitu
+            return false;
+        }
         if (shouldLogProfile() == false)
         {
             return false;
         }
-        String className = profile.getDomainClass().getSimpleName();
+        String className = domainClass.getSimpleName();
         String[] skippedClasses = {"EnumerationTypeBean", "TemplatesGroupBean"};
         for (String skippedClass : skippedClasses)
         {


### PR DESCRIPTION
FIX NPE ktory nastava v pripade ziskania nazvu entity pri internych / sekvencnych prikazoch (NEXTVAL, DDL, ...)