### PR TITLE
feature/58317-15-multiweb-rename-domain

### DIFF
--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -122,7 +122,7 @@ V jednom WebJET CMS v môžete mať viacero (desiatky) domén a následne mať m
 - Prihlásenie - zrýchlené načítanie úvodnej stránky v administrácii - pridaná vyrovnávacia pamäť pre zoznam posledných stránok, zmenených stránok a auditných záznamov (#58589).
 - Export/import súborov - upravený dizajn dialógového okna a responzívne zobrazenie formulárových polí podľa aktuálneho dizajnu administrácie (#58581).
 - Webové stránky - doplnené zvýraznenie elementu nad ktorým je vyvolané kontextové menu. Dôležité ak chcete vykonať akciu Zmazať element, aby ste presne videli ktorý element je označený (#OSK675).
-- Multiweb - doplnená možnosť premenovať existujúcu doménu (#58317-15).
+- Multiweb - doplnená možnosť premenovať existujúcu doménu + presmerovanie po premenovaní (#58317-15).
 
 ### Oprava chýb
 

--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -122,6 +122,7 @@ V jednom WebJET CMS v môžete mať viacero (desiatky) domén a následne mať m
 - Prihlásenie - zrýchlené načítanie úvodnej stránky v administrácii - pridaná vyrovnávacia pamäť pre zoznam posledných stránok, zmenených stránok a auditných záznamov (#58589).
 - Export/import súborov - upravený dizajn dialógového okna a responzívne zobrazenie formulárových polí podľa aktuálneho dizajnu administrácie (#58581).
 - Webové stránky - doplnené zvýraznenie elementu nad ktorým je vyvolané kontextové menu. Dôležité ak chcete vykonať akciu Zmazať element, aby ste presne videli ktorý element je označený (#OSK675).
+- Multiweb - doplnená možnosť premenovať existujúcu doménu (#58317-15).
 
 ### Oprava chýb
 

--- a/src/main/java/sk/iway/iwcm/Identity.java
+++ b/src/main/java/sk/iway/iwcm/Identity.java
@@ -45,7 +45,7 @@ public class Identity extends UserDetails
 		{
 			PropertyUtils.copyProperties(this, user);
 			//permissions treba precistit, aby sa korektne znova nasetovali
-			if (disabledItemsTable != null) disabledItemsTable.clear();
+			if (disabledItemsTable != null) disabledItemsTable = new Hashtable<>(); //do not use disabledItemsTable.clear as it also clear table in user object (its copied by reference)
 			UsersDB.setDisabledItems(this);
 		}
 		catch (Exception ex)

--- a/src/main/java/sk/iway/iwcm/admin/layout/LayoutService.java
+++ b/src/main/java/sk/iway/iwcm/admin/layout/LayoutService.java
@@ -120,6 +120,9 @@ public class LayoutService
                     javascript.append("nopermsJavascript[\"ver-multiweb\"]=true;\n");
                 }
 
+                css.append(".noperms-install-"+Constants.getInstallName()+" { display: none !important; }\n");
+                javascript.append("nopermsJavascript[\"install-"+Constants.getInstallName()+"\"]=true;\n");
+
                 //ve need to verify this modules because they are used in FE components
                 //and if user has no perms for them, they should not be visible in admin
                 String[] modulesToCheck = {"cmp_ai_tools", "cmp_ai_stats", "cmp_ai_button"};

--- a/src/main/java/sk/iway/iwcm/doc/GroupDetails.java
+++ b/src/main/java/sk/iway/iwcm/doc/GroupDetails.java
@@ -94,7 +94,7 @@ public class GroupDetails implements Cloneable, DocGroupInterface
 	@DataTableColumn(
 		renderFormat = "dt-format-text",
 		title = "[[#{groupedit.domain}]]",
-		className = "DTE_Field_Has_Checkbox noperms-ver-multiweb",
+		className = "DTE_Field_Has_Checkbox noperms-install-cloud",
 		visible = false,
 		perms = "multiDomain",
 		editor = {

--- a/src/main/java/sk/iway/iwcm/doc/GroupEditorField.java
+++ b/src/main/java/sk/iway/iwcm/doc/GroupEditorField.java
@@ -121,7 +121,7 @@ public class GroupEditorField extends BaseEditorFields {
                     @DataTableColumnEditorAttr(key = "editor.apply_for_all_sub_folders_and_sub_pages", value = "true") }) })
     private boolean forceUrlDirNameChange;
 
-    @DataTableColumn(renderFormat = "dt-format-checkbox", title = "[[#{}]]", visible = false, sortAfter = "domainName", editor = {
+    @DataTableColumn(renderFormat = "dt-format-checkbox", title = "[[#{}]]", visible = false, sortAfter = "domainName", className = "noperms-install-cloud", editor = {
             @DataTableColumnEditor(type = "checkbox", tab = "basic", options = {
                     @DataTableColumnEditorAttr(key = "groupedit.changeDomainRedirects", value = "true") }) })
     private boolean forceDomainNameChange;

--- a/src/main/java/sk/iway/iwcm/editor/rest/GroupsRestController.java
+++ b/src/main/java/sk/iway/iwcm/editor/rest/GroupsRestController.java
@@ -692,6 +692,11 @@ public class GroupsRestController extends DatatableRestControllerV2<GroupDetails
     @Override
     public void validateEditor(HttpServletRequest request, DatatableRequest<Long, GroupDetails> target, Identity user, Errors errors, Long id, GroupDetails entity) {
 
+        if (InitServlet.isTypeCloud() && "cloud".equals(Constants.getInstallName()) && CloudToolsForCore.isControllerDomain()==false) {
+            //force current domain for WebJET Cloud
+            entity.setDomainName(CloudToolsForCore.getDomainName());
+        }
+
         if (entity.getGroupId()>0 && GroupsDB.isGroupEditable(user, entity.getGroupId())==false) {
             errors.rejectValue("errorField.groupId", "403", Prop.getInstance().getText("user.rights.no_folder_rights"));
             return;

--- a/src/main/java/sk/iway/iwcm/editor/rest/GroupsRestController.java
+++ b/src/main/java/sk/iway/iwcm/editor/rest/GroupsRestController.java
@@ -706,8 +706,16 @@ public class GroupsRestController extends DatatableRestControllerV2<GroupDetails
 			if (oldGroup == null || oldGroup.getDomainName().equals(CloudToolsForCore.getDomainName())==false)
 			{
 				errors.rejectValue("errorField.domainName", "403", Prop.getInstance().getText("user.rights.no_folder_rights"));
-                return;
+	            return;
 			}
+
+            if (Tools.isNotEmpty(entity.getDomainName()) && oldGroup.getDomainName().equalsIgnoreCase(entity.getDomainName())==false) {
+                int domainCount = new SimpleQuery().forInt("SELECT COUNT(*) FROM groups WHERE LOWER(domain_name)=LOWER(?)", entity.getDomainName());
+                if (domainCount > 0) {
+                    errors.rejectValue("errorField.domainName", "403", Prop.getInstance(request).getText("groupedit.domain_already_exists"));
+                    return;
+                }
+            }
 		}
 
         if ("remove".equals(target.getAction())) return;

--- a/src/main/java/sk/iway/iwcm/editor/rest/GroupsRestController.java
+++ b/src/main/java/sk/iway/iwcm/editor/rest/GroupsRestController.java
@@ -219,8 +219,8 @@ public class GroupsRestController extends DatatableRestControllerV2<GroupDetails
 
     @Override
     public void beforeSave(GroupDetails entity) {
-        if (InitServlet.isTypeCloud() && CloudToolsForCore.isControllerDomain()==false) {
-            //force current domain
+        if (InitServlet.isTypeCloud() && "cloud".equals(Constants.getInstallName()) && CloudToolsForCore.isControllerDomain()==false) {
+            //force current domain for WebJET Cloud
             entity.setDomainName(CloudToolsForCore.getDomainName());
         }
         super.beforeSave(entity);
@@ -270,6 +270,14 @@ public class GroupsRestController extends DatatableRestControllerV2<GroupDetails
                     //read systemGroupIds for later use
                     systemGroupIds = groupsDB.getSubgroupsIds(system.getGroupId());
                 }
+            }
+            if (oldGroupDetails != null && entity.getGroupName().equals(oldGroupDetails.getDomainName())) {
+                //if group name is same as domain name, we also update group name to reflect new domain name
+                entity.setGroupName(entity.getDomainName());
+            }
+            if (oldGroupDetails != null && entity.getNavbarName().equals(oldGroupDetails.getDomainName())) {
+                //if group name is same as domain name, we update group navbar too
+                entity.setNavbarName(entity.getDomainName());
             }
         }
 
@@ -478,6 +486,7 @@ public class GroupsRestController extends DatatableRestControllerV2<GroupDetails
         }
 
         int parGroupId = entity.getParentGroupId();
+        boolean domainRenamed = false;
         if ((parGroupId < 1 || Constants.getBoolean("multiDomainEnableNested")) && Tools.isNotEmpty(entity.getDomainName()) && entity.getEditorFields().isForceDomainNameChange())
         {
             if(parGroupId < 1) {
@@ -485,17 +494,24 @@ public class GroupsRestController extends DatatableRestControllerV2<GroupDetails
             }
 
             String groupIds = groupsDB.getSubgroupsIds(entity.getGroupId());
+            domainRenamed = true;
+            forceReloadNewDomainName = true;
 
             Adminlog.add(Adminlog.TYPE_GROUP, "Force domain to subgroups: " + groupIds, entity.getGroupId(), entity.getTempId());
 
-            //updatni groups
-            new SimpleQuery().execute("UPDATE groups SET domain_name=? WHERE group_id IN ("+groupIds+")",entity.getDomainName());
-
-            if (systemGroupIds!=null) {
-                Adminlog.add(Adminlog.TYPE_GROUP, "Force domain to system subgroups: " + systemGroupIds, -1, -1);
-
+            if (InitServlet.isTypeCloud() && oldGroupDetails != null && Tools.isNotEmpty(oldGroupDetails.getDomainName())) {
+                //in multiweb rename domain in all root groups
+                new SimpleQuery().execute("UPDATE groups SET domain_name=? WHERE domain_name=?", entity.getDomainName(), oldGroupDetails.getDomainName());
+            } else {
                 //updatni groups
-                new SimpleQuery().execute("UPDATE groups SET domain_name=? WHERE group_id IN ("+systemGroupIds+")", entity.getDomainName());
+                new SimpleQuery().execute("UPDATE groups SET domain_name=? WHERE group_id IN ("+groupIds+")",entity.getDomainName());
+
+                if (systemGroupIds!=null) {
+                    Adminlog.add(Adminlog.TYPE_GROUP, "Force domain to system subgroups: " + systemGroupIds, -1, -1);
+
+                    //updatni groups
+                    new SimpleQuery().execute("UPDATE groups SET domain_name=? WHERE group_id IN ("+systemGroupIds+")", entity.getDomainName());
+                }
             }
 
             //aktualizuj presmerovania
@@ -648,6 +664,15 @@ public class GroupsRestController extends DatatableRestControllerV2<GroupDetails
         }
 
         if (forceReloadNewDomainName) {
+            if (domainRenamed && InitServlet.isTypeCloud()) {
+                //force reload to new domain after change domain name
+                GroupDetails entityReload = new GroupDetails();
+                entityReload.setDomainName(entity.getDomainName());
+                entityReload.setGroupId(-2);
+                entityReload.setEditorFields(new GroupEditorField());
+                entity = entityReload;
+            }
+
             //novo vytvorena domena, potrebujeme vyvolat reload stranky
             //fejkneme to cez atribut forceDomainNameChange, na ktory uz pocuvame v pug subore
             entity.getEditorFields().setForceDomainNameChange(true);

--- a/src/main/webapp/WEB-INF/classes/text.properties
+++ b/src/main/webapp/WEB-INF/classes/text.properties
@@ -3410,6 +3410,7 @@ checkform.fail_probablySpamBot=Formulár bol detekovaný ako SPAM (nevyžiadaná
 components.forum.error.questionEmpty=Príspevok je prázdny, nie je možné ho zadať. Zadajte prosím text príspevku.
 
 groupedit.domain=Doména
+groupedit.domain_already_exists=Zadaná doména už existuje
 
 components.basket.addToBasket=Pridať do košíka
 

--- a/src/main/webapp/WEB-INF/classes/text_cz.properties
+++ b/src/main/webapp/WEB-INF/classes/text_cz.properties
@@ -3410,6 +3410,7 @@ checkform.fail_probablySpamBot=Formulář byl detekovaný jako SPAM (nevyžádan
 components.forum.error.questionEmpty=Příspěvek je prázdný, není možné ho zadat. Vložte prosím text příspěvku.
 
 groupedit.domain=Doména
+groupedit.domain_already_exists=Zadaná doména již existuje
 
 components.basket.addToBasket=Přidat do košíku
 

--- a/src/main/webapp/WEB-INF/classes/text_de.properties
+++ b/src/main/webapp/WEB-INF/classes/text_de.properties
@@ -3403,6 +3403,7 @@ checkform.fail_probablySpamBot=Formular wurde als Spam identifiziert. Sie benöt
 components.forum.error.questionEmpty=Nachricht ist leer! Bitte Text eingeben.
 
 groupedit.domain=Domäne
+groupedit.domain_already_exists=Die angegebene Domäne existiert bereits
 
 components.basket.addToBasket=Zum Warenkorb hinzufügen
 

--- a/src/main/webapp/WEB-INF/classes/text_en.properties
+++ b/src/main/webapp/WEB-INF/classes/text_en.properties
@@ -3410,6 +3410,7 @@ checkform.fail_probablySpamBot=Form was detected as SPAM. You need to have a sta
 components.forum.error.questionEmpty=Message is empty. Please enter message.
 
 groupedit.domain=Domain
+groupedit.domain_already_exists=The specified domain already exists
 
 components.basket.addToBasket=Add to basket
 

--- a/src/main/webapp/admin/v9/views/pages/webpages/web-pages-list.pug
+++ b/src/main/webapp/admin/v9/views/pages/webpages/web-pages-list.pug
@@ -501,8 +501,8 @@ block content
                     });
 
                     function showHideDomainName(parentGroupId) {
-                        //always hide in multiweb
-                        if (WJ.hasPermission("ver-multiweb") == false) parentGroupId = 1;
+                        //always hide in cloud
+                        if (WJ.hasPermission("ver-multiweb") == false && WJ.hasPermission("install-cloud") == false) parentGroupId = 1;
                         window.setTimeout(function() {
                             try {
                                 if (parentGroupId > 0) {
@@ -538,6 +538,9 @@ block content
                                 //console.log("Binding groups DTED events");
                                 groupsDatatableEventsBinded = true;
                                 //navbar nastaveny podla title
+                                $("#DTE_Field_domainName").on("keyup", function() {
+                                    $("#DTE_Field_editorFields-forceDomainNameChange_0").prop("checked", true);
+                                });
                                 $("#DTE_Field_groupName").on("blur", function() {
                                     if ($("#DTE_Field_navbarName").val()=="") {
                                         $("#DTE_Field_navbarName").val($("#DTE_Field_groupName").val());
@@ -581,7 +584,23 @@ block content
                             //toto sa vyvola, ked sa zmeni domena na adresari
                             //console.log("e.detail.data=", e.detail.data);
                             if (e.detail.data.editorFields.forceDomainNameChange === true) {
-                                window.location="/admin/v9/webpages/web-pages-list/?groupid="+e.detail.data.groupId;
+                                let returnedGroupId = e.detail.data.groupId;
+                                if (returnedGroupId > 0) {
+                                    //console.log("FORCE RELOAD, reloading page with groupId=", returnedGroupId);
+                                    window.location="/admin/v9/webpages/web-pages-list/?groupid="+returnedGroupId;
+                                } else if (returnedGroupId == -2) {
+                                    //get domain name from current group and redirect to that domain
+                                    let currentGroup = e.detail.data;
+                                    if (currentGroup != null && currentGroup.domainName != null && currentGroup.domainName != "") {
+                                        let currentUrl = window.location.href;
+                                        let newUrl = currentUrl.replace(window.location.hostname, currentGroup.domainName);
+                                        window.location = newUrl;
+                                    } else {
+                                        window.location="/admin/v9/";
+                                    }
+                                } else {
+                                    window.location="/admin/v9/";
+                                }
                             }
                             //window.location=window.location.pathname;
                             setTimeout(()=>{


### PR DESCRIPTION
V multiwebu jsem chtěl přejmenovat doménu www.xxx.cz na yyy.cz. Zaškrtnul jsem v editaci hlavního adresáře také „Změnit přesměrování domény, konfigurační proměnné a překladové texty s prefixem domény“. Dřív toto normálně fungovalo.
Nyní se ale v tabulce groups změní doména jen u hlavního adresáře webu a u složky Systém a Koš. Ostatní adresáře zůstanou pod původní doménou. Navíc se tam záhadně namnožily složky System a Koš