### PR TITLE
feature/58577 pridat moznost zaokruhlit ceny v eshope clean

### DIFF
--- a/docs/sk/CHANGELOG-2026.md
+++ b/docs/sk/CHANGELOG-2026.md
@@ -94,6 +94,8 @@ V jednom WebJET CMS v môžete mať viacero (desiatky) domén a následne mať m
 
 ### Aplikácie
 
+- Elektronický obchod - pridané voliteľné [zaokrúhľovanie cien](redactor/apps/basket/rounding.md), aby sa košík počítal zo zobrazenej ceny za kus. Počet desatinných miest určuje `currencyFormat`; šablóny so značkou `iway:curr` prevezmú nové formátovanie automaticky (#58577).
+
 - Číselníky - pre pomenované reťazcové polia je možné v novej karte [Typy reťazcových polí](redactor/apps/enumeration/README.md#karta-typy-reťazcových-polí) nastaviť typ poľa, možnosti výberu, povinnosť, pomocný text a obmedzenia dĺžky rovnako ako pri voliteľných poliach. Ponuka a názvy konfigurácií vychádzajú z poslednej uloženej verzie typu číselníka. Nepomenované polia zostávajú skryté, nevyhodnocujú sa ako povinné a polia bez špecifickej konfigurácie sa zobrazia ako bežný text. Staršie vlastné Excel šablóny a integrácie REST API je potrebné upraviť z atribútov `string1` až `string12` na `fieldA` až `fieldL` (#58641).
 
 ![](redactor/apps/enumeration/editor_stringFieldTypes.png)

--- a/docs/sk/redactor/apps/basket/README.md
+++ b/docs/sk/redactor/apps/basket/README.md
@@ -1,5 +1,7 @@
 # Elektronický obchod
 
+Voliteľné [zaokrúhľovanie cien](rounding.md) počíta košík zo zobrazených cien za kus s DPH, aby skryté desatinné miesta nemenili celkovú cenu.
+
 Cez aplikáciu E-shop môžete vytvoriť a spravovať jednoduchý elektronický obchod. V rámci aplikácie definujete jednotlivé produkty a ich atribúty (napr. veľkosť, farba), spôsoby doručenia, či platby. Aplikácia evidujete zoznam prijatých objednávok, umožňuje nastavovať ich stav s možnosťou notifikácie zmien v objednávke na zákazníkov email.
 
 ## Nastavenia aplikácie

--- a/docs/sk/redactor/apps/basket/rounding.md
+++ b/docs/sk/redactor/apps/basket/rounding.md
@@ -1,0 +1,57 @@
+# Zaokrúhľovanie cien
+
+Zaokrúhľovanie zabezpečí, aby sa cena v košíku počítala zo zobrazenej ceny za kus s DPH. Napríklad cena **1,594 €** sa zaokrúhli na **1,59 €** a zákazník za tri kusy zaplatí **4,77 €**.
+
+## Zapnutie
+
+V konfigurácii nastavte:
+
+- **`basketRoundPrices=true`** – zapne zaokrúhľovanie. Predvolená hodnota `false` ponechá pôvodný výpočet.
+- **`currencyFormat=0.00`** – nastaví cenu za kus na dve desatinné miesta. Pre lacné produkty môžete použiť viac miest.
+
+Funkcia podporuje EUR a CZK. Obchod aj objednávka používajú nastavenú systémovú menu.
+
+## Ako sa počíta cena
+
+1. Cena za kus s DPH sa po zľavách a prípadnom prepočte meny zaokrúhli podľa `currencyFormat`.
+2. Zaokrúhlená cena sa vynásobí počtom kusov. Výsledná suma za produkt sa zaokrúhli na dve desatinné miesta.
+3. Košík sčíta sumy za produkty, dopravu a platbu. Poplatky sa zaokrúhľujú rovnakým spôsobom.
+
+Používa sa bežné zaokrúhľovanie: napríklad **1,594 → 1,59** a **1,595 → 1,60**. DPH sa počíta zo súčtu cien s DPH pre každú sadzbu osobitne a rozdelí sa medzi položky tak, aby súčty sedeli.
+
+### Počet desatinných miest
+
+Príklad pre pôvodnú cenu **1,594 s DPH** a **3 kusy**:
+
+| `currencyFormat` | Zobrazená cena za kus | Suma za 3 kusy na úhradu |
+| --- | ---: | ---: |
+| `0` | 2,00 | 6,00 |
+| `0.0` | 1,60 | 4,80 |
+| `0.00` | 1,59 | 4,77 |
+| `0.0000` | 1,5940 | 4,78 |
+| `0.00##` | 1,594 | 4,78 |
+
+`0` znamená povinnú číslicu, `#` voliteľnú. Vzor `0.00##` preto zachová až štyri desatinné miesta, ale nezobrazuje zbytočné koncové nuly. Ceny sa vždy zobrazujú aspoň na dve miesta. Pri `0.0000` sa aj suma na úhradu 4,78 zobrazí ako 4,7800.
+
+### Veľmi lacné produkty
+
+Pri rezistore za **0,0001 €** použite napríklad `currencyFormat=0.0000`. Potom **10 000 kusov stojí 1,00 €**. Pri `0.00` by sa už cena za kus zaokrúhlila na nulu. Aj pri vyššej presnosti sa výsledná suma za produkt zaokrúhli na centy; suma menšia ako 0,005 € bude nulová.
+
+Pre veľké množstvá upravte aj limit `basketMaxQty`, ktorý je predvolene 1000 kusov.
+
+## Euro a česká koruna
+
+Pri **karte alebo bankovom prevode** funguje výpočet rovnako v EUR aj CZK: cena za kus sa riadi `currencyFormat` a suma na úhradu má presnosť na dve desatinné miesta.
+
+Rozdiel je pri výbere **hotovosti**:
+
+- **Slovensko:** výsledná hotovostná suma sa zaokrúhľuje na najbližších 0,05 €. Napríklad 4,77 € → 4,75 €. Ak je celá platba len 0,01 € alebo 0,02 €, zaokrúhli sa na 0,05 €.
+- **Česko:** výsledná hotovostná suma sa zaokrúhľuje na celé koruny. Napríklad 4,77 Kč → 5 Kč.
+
+**Hotovostné zaokrúhlenie táto funkcia nevykonáva.** Rieši ho pokladnica alebo kuriér podľa skutočného spôsobu platby. Dobierka nemusí znamenať hotovosť – kuriérovi možno zaplatiť aj kartou.
+
+## Pred nasadením
+
+Šablóny používajúce značku `iway:curr` prevezmú nové formátovanie automaticky. Vlastné výpočty cien treba overiť osobitne. Po zapnutí vymažte cache zoznamov produktov a vyskúšajte nákup. Pri odoslaní objednávky sa ceny produktov obnovia podľa aktuálnych cien v obchode.
+
+Nastavenie presnosti zvoľte pri spustení obchodu a neskôr ho meňte opatrne. Zmena nastavenia **nemení uloženú celkovú cenu starších objednávok**, môže však zmeniť zobrazenie ich položiek a rozpis DPH. Pri úprave položiek sa objednávka prepočíta podľa aktuálnych nastavení.

--- a/src/main/java/sk/iway/iwcm/Constants.java
+++ b/src/main/java/sk/iway/iwcm/Constants.java
@@ -344,6 +344,8 @@ public class Constants {
 		// namiesto redirectovat (ked nie je pouzity LinkType=HTML)
 		setBoolean("forwardVirtualPath", false);
 
+		setBoolean("basketRoundPrices", false, MOD_BASKET,
+			"Round VAT-inclusive selling units to currencyFormat precision before multiplying quantities; line totals settle to cents. Stored invoice totals remain unchanged when configuration changes.");
 		setString("basketPriceField", "fieldK", MOD_BASKET,
 				"Názov poľa v ktorom je v stránke uvedená cena produktu. Štandardne nastavené na hodnotu fieldK");
 		setString("basketProductTypeField", "fieldI", MOD_BASKET,

--- a/src/main/java/sk/iway/iwcm/components/basket/delivery_methods/jpa/DeliveryMethodEntity.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/delivery_methods/jpa/DeliveryMethodEntity.java
@@ -137,6 +137,8 @@ public class DeliveryMethodEntity extends SupportMethodEntity {
         if(price == null) return BigDecimal.ZERO;
         if(vat == null || vat < 1) return price;
 
+        if (sk.iway.iwcm.components.basket.rest.BasketPricingService.isEnabled())
+            return price.multiply(BigDecimal.valueOf(100L + vat)).movePointLeft(2);
         BigDecimal bdVat = new BigDecimal(vat);
         return price
             .multiply(BigDecimal.ONE.add(bdVat.divide(new BigDecimal("100"), 4, RoundingMode.HALF_UP)))

--- a/src/main/java/sk/iway/iwcm/components/basket/jpa/BasketInvoiceEntity.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/jpa/BasketInvoiceEntity.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import lombok.Getter;
 import lombok.Setter;
+import sk.iway.iwcm.components.basket.rest.BasketPricingService;
 import sk.iway.Password;
 import sk.iway.iwcm.Adminlog;
 import sk.iway.iwcm.Constants;
@@ -44,6 +45,7 @@ public class BasketInvoiceEntity extends ActiveRecordRepository implements Seria
 
 	@PrePersist
 	public void onPrePersist() {
+		if (priceToPayVat != null) return;
 		//After insert update invoice stats
 		ProductListService.updateInvoiceStats(this.getId(), this.browserId, true);
 	}
@@ -400,7 +402,9 @@ public class BasketInvoiceEntity extends ActiveRecordRepository implements Seria
 	@JsonIgnore
 	public List<BasketInvoiceItemEntity> getBasketItems() {
 		BasketInvoiceItemsRepository biir = Tools.getSpringBean("basketInvoiceItemsRepository", BasketInvoiceItemsRepository.class);
-		return biir.findAllByBrowserIdAndDomainId(browserId, domainId);
+		List<BasketInvoiceItemEntity> items = biir.findAllByBrowserIdAndDomainId(browserId, domainId);
+		if (BasketPricingService.isEnabled()) BasketPricingService.allocateVat(items);
+		return items;
 	}
 
 	@JsonIgnore

--- a/src/main/java/sk/iway/iwcm/components/basket/jpa/BasketInvoiceItemEditorFields.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/jpa/BasketInvoiceItemEditorFields.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import lombok.Getter;
 import lombok.Setter;
+import sk.iway.tags.CurrencyTag;
 import sk.iway.iwcm.system.datatable.BaseEditorFields;
 import sk.iway.iwcm.system.datatable.DataTableColumnType;
 import sk.iway.iwcm.system.datatable.annotations.DataTableColumn;
@@ -18,6 +19,16 @@ public class BasketInvoiceItemEditorFields extends BaseEditorFields {
         hiddenEditor = true, hidden = false, visible = true, sortAfter = "id", className = "allow-html", orderable = false, filter = false
     )
     private String statusIcons;
+
+    @DataTableColumn(
+        inputType = DataTableColumnType.DISABLED,
+        renderFormat = "dt-format-text",
+        title = "components.basket.invoice.items.unit_price_with_vat",
+        sortAfter = "itemPrice",
+        orderable = false,
+        filter = false
+    )
+    private String unitPriceWithVatFormatted;
 
     @DataTableColumn(
         inputType = DataTableColumnType.NUMBER,
@@ -48,14 +59,15 @@ public class BasketInvoiceItemEditorFields extends BaseEditorFields {
     public void fromBasketInvoiceItem(BasketInvoiceItemEntity originalEntity, List<LabelValue> paymentMethods, List<LabelValue> deliveryMethods) {
         StringBuilder iconsHtml = new StringBuilder();
 
-        withoutVatComplete = originalEntity.getItemPrice().multiply( BigDecimal.valueOf(originalEntity.getItemQty()) );
+        unitPriceWithVatFormatted = CurrencyTag.formatNumber(originalEntity.getItemPriceVat());
+        withoutVatComplete = originalEntity.getItemPriceQty();
         itemVat = originalEntity.getItemVat() + "%";
         withVatComplete = originalEntity.getItemPriceVatQty();
 
-        if(originalEntity.getItemId() == 0 && paymentMethods.stream().anyMatch(payment -> payment.getLabel().equals(originalEntity.getItemTitle()))) {
+        if(originalEntity.getItemIdInt() == 0 && paymentMethods != null && paymentMethods.stream().anyMatch(payment -> payment.getLabel().equals(originalEntity.getItemTitle()))) {
             //This is payment method
             iconsHtml.append("<i class=\"ti ti-cash\" style=\"width: 1.25em;\"></i>");
-        } else if(originalEntity.getItemId() == 0 && deliveryMethods.stream().anyMatch(delivery -> delivery.getLabel().equals(originalEntity.getItemTitle()))) {
+        } else if(originalEntity.getItemIdInt() == 0 && deliveryMethods != null && deliveryMethods.stream().anyMatch(delivery -> delivery.getLabel().equals(originalEntity.getItemTitle()))) {
             //This is transport method
             iconsHtml.append("<i class=\"ti ti-truck-delivery\" style=\"width: 1.25em;\"></i>");
         } else {

--- a/src/main/java/sk/iway/iwcm/components/basket/jpa/BasketInvoiceItemEntity.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/jpa/BasketInvoiceItemEntity.java
@@ -1,6 +1,7 @@
 package sk.iway.iwcm.components.basket.jpa;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Date;
 
 import jakarta.persistence.Column;
@@ -20,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
 import lombok.Setter;
+import sk.iway.iwcm.components.basket.rest.BasketPricingService;
 import sk.iway.iwcm.components.basket.rest.EshopService;
 import sk.iway.iwcm.doc.DocDB;
 import sk.iway.iwcm.doc.DocDetails;
@@ -75,6 +77,15 @@ public class BasketInvoiceItemEntity {
 	)
 	private BigDecimal itemPrice;
 
+	/** Calculated for the current request; the existing itemPrice column retains the net unit price. */
+	@Transient
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	private BigDecimal roundedUnitPriceVat;
+
+	@Transient
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	private BigDecimal lineVatAmount;
+
 	@Column(name="item_qty")
 	@DataTableColumn(
 		inputType = DataTableColumnType.NUMBER,
@@ -123,7 +134,20 @@ public class BasketInvoiceItemEntity {
 	 * @return
 	 */
 	public BigDecimal getItemPriceQty() {
+		if (hasRoundedPrice()) {
+			if (lineVatAmount != null) return getItemPriceVatQty().subtract(lineVatAmount);
+			return getRoundedNetUnitPrice().multiply(BigDecimal.valueOf(getItemQty()));
+		}
 		return BigDecimal.valueOf(getItemQty()).multiply(itemPrice);
+	}
+
+	public boolean hasRoundedPrice() {
+		return roundedUnitPriceVat != null;
+	}
+
+	private BigDecimal getRoundedNetUnitPrice() {
+		return roundedUnitPriceVat.multiply(BigDecimal.valueOf(100))
+			.divide(BigDecimal.valueOf(100L + getItemVat()), Math.max(12, roundedUnitPriceVat.stripTrailingZeros().scale()), RoundingMode.HALF_UP);
 	}
 
 	public int getBasketItemId() {
@@ -135,10 +159,7 @@ public class BasketInvoiceItemEntity {
 	 * @return
 	 */
 	public BigDecimal getItemPriceVat() {
-		//vypocet DPH (aka VAT)
-		BigDecimal vat = BigDecimal.valueOf( getItemVat() );
-		vat = ( vat.divide(BigDecimal.valueOf(100)) ).add(BigDecimal.valueOf(1));
-		return getItemPrice().multiply(vat);
+		return hasRoundedPrice() ? roundedUnitPriceVat : BasketPricingService.sellingPriceWithVat(getItemPrice(), BigDecimal.valueOf(getItemVat()));
 	}
 
 	public boolean itemAlreadyPurchased() {
@@ -150,7 +171,9 @@ public class BasketInvoiceItemEntity {
 	 * @return
 	 */
 	public BigDecimal getItemPriceVatQty() {
-		return getItemPriceVat().multiply( BigDecimal.valueOf(getItemQty()) );
+		BigDecimal grossUnit = getItemPriceVat();
+		return hasRoundedPrice() || BasketPricingService.isEnabled()
+			? BasketPricingService.roundLineGross(grossUnit, getItemQty()) : grossUnit.multiply(BigDecimal.valueOf(getItemQty()));
 	}
 
 	public String getTitle() {
@@ -180,41 +203,41 @@ public class BasketInvoiceItemEntity {
 	 */
 
 	public BigDecimal getLocalPrice(HttpServletRequest request, String currency) {
+		if (hasRoundedPrice()) return getRoundedNetUnitPrice();
 		if (itemAlreadyPurchased())
 			return getItemPrice();
 		return getDoc().getLocalPrice(request, currency);
 	}
 
 	public BigDecimal getLocalPrice(HttpServletRequest request) {
+		if (hasRoundedPrice()) return getRoundedNetUnitPrice();
 		if (itemAlreadyPurchased())
 			return getItemPrice();
 		return getDoc().getLocalPrice(request);
 	}
 
 	public BigDecimal getItemLocalPriceQty(HttpServletRequest request, String currency) {
+		if (hasRoundedPrice()) return getItemPriceQty();
 		return BigDecimal.valueOf(getItemQty()).multiply( getLocalPrice(request, currency) );
 	}
 
 	public BigDecimal getItemLocalPriceQty(HttpServletRequest request) {
+		if (hasRoundedPrice()) return getItemPriceQty();
 		return BigDecimal.valueOf(getItemQty()).multiply( getLocalPrice(request) );
 	}
 
 	public BigDecimal getItemLocalPriceVatQty(HttpServletRequest request, String currency) {
-		BigDecimal vat = BigDecimal.valueOf(getItemVat());
-		vat = (vat.divide(BigDecimal.valueOf(100))).add(BigDecimal.valueOf(1));
-		return vat.multiply(BigDecimal.valueOf(getItemQty())).multiply(getLocalPrice(request, currency));
+		BigDecimal grossUnit = getLocalPriceVat(request, currency);
+		return hasRoundedPrice() || BasketPricingService.isEnabled()
+			? BasketPricingService.roundLineGross(grossUnit, getItemQty()) : grossUnit.multiply(BigDecimal.valueOf(getItemQty()));
 	}
 
 	public BigDecimal getLocalPriceVat(HttpServletRequest request, String currency) {
-		BigDecimal vat = BigDecimal.valueOf(getItemVat());
-		vat = (vat.divide(BigDecimal.valueOf(100))).add(BigDecimal.valueOf(1));
-		return vat.multiply( getLocalPrice(request, currency) );
+		return hasRoundedPrice() ? roundedUnitPriceVat : BasketPricingService.sellingPriceWithVat(getLocalPrice(request, currency), BigDecimal.valueOf(getItemVat()));
 	}
 
 	public BigDecimal getLocalPriceVat(HttpServletRequest request) {
-		BigDecimal vat = BigDecimal.valueOf(getItemVat());
-		vat = (vat.divide(BigDecimal.valueOf(100))).add(BigDecimal.valueOf(1));
-		return vat.multiply( getLocalPrice(request) );
+		return hasRoundedPrice() ? roundedUnitPriceVat : BasketPricingService.sellingPriceWithVat(getLocalPrice(request), BigDecimal.valueOf(getItemVat()));
 	}
 
 	public BigDecimal getItemLocalPriceVatQty(HttpServletRequest request) {

--- a/src/main/java/sk/iway/iwcm/components/basket/payment_methods/rest/BasePaymentMethod.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/payment_methods/rest/BasePaymentMethod.java
@@ -251,7 +251,9 @@ public abstract class BasePaymentMethod {
             BasketInvoiceItemEntity tmp = new BasketInvoiceItemEntity();
             getPaymentMethodCost(tmp, paymentMethod);
 
-            paymentMethods.add( new MethodDto(paymentMethod.getPaymentMethodName(), SupportService.getCustomerTitle(tmp.getItemPriceVat(), request, prop, annotation), tmp.getItemPriceVat()) );
+            BigDecimal gross = sk.iway.iwcm.components.basket.rest.BasketPricingService.isEnabled()
+                ? tmp.getItemPrice().multiply(BigDecimal.valueOf(100L + tmp.getItemVat())).movePointLeft(2) : tmp.getItemPriceVat();
+            paymentMethods.add(new MethodDto(paymentMethod.getPaymentMethodName(), SupportService.getCustomerTitle(gross, request, prop, annotation), gross));
         }
     }
 

--- a/src/main/java/sk/iway/iwcm/components/basket/payment_methods/rest/GoPayService.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/payment_methods/rest/GoPayService.java
@@ -3,6 +3,8 @@ package sk.iway.iwcm.components.basket.payment_methods.rest;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.Locale;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -28,7 +30,6 @@ import cz.gopay.api.v3.model.payment.support.PayerContact;
 import cz.gopay.api.v3.model.payment.support.PaymentInstrument;
 import sk.iway.iwcm.Logger;
 import sk.iway.iwcm.Tools;
-import sk.iway.iwcm.common.BasketTools;
 import sk.iway.iwcm.common.CloudToolsForCore;
 import sk.iway.iwcm.components.basket.jpa.BasketInvoiceEntity;
 import sk.iway.iwcm.components.basket.jpa.BasketInvoiceItemEntity;
@@ -119,7 +120,7 @@ public class GoPayService extends BasePaymentMethod {
                 .build();
     }
 
-    private final BasePayment getPayment(BasketInvoiceEntity bie, String returnUrl, PaymentMethodEntity paymentMethod, BasketInvoiceItemsRepository biir, BasketInvoicePaymentsRepository bipr) {
+    final BasePayment getPayment(BasketInvoiceEntity bie, String returnUrl, PaymentMethodEntity paymentMethod, BasketInvoiceItemsRepository biir, BasketInvoicePaymentsRepository bipr) {
         Date currentDate = new Date();
 
         //Prepare payment builder
@@ -131,28 +132,24 @@ public class GoPayService extends BasePaymentMethod {
                 .inLang( bie.getUserLng().toUpperCase() )
                 .toEshop( Long.valueOf(paymentMethod.getFieldD()) );
 
-        //Add itemns to payment
-        BigDecimal totalPriceToPay = new BigDecimal(0);
-        for(BasketInvoiceItemEntity item : biir.findAllByInvoiceIdAndDomainId(bie.getId(), CloudToolsForCore.getDomainId())) {
-            totalPriceToPay = totalPriceToPay.add( item.getItemPriceVatQty() );
-            payment.addItem(
-                basketItemToOrderItem(item)
-            );
-        }
-
+        List<BasketInvoiceItemEntity> items = biir.findAllByInvoiceIdAndDomainId(bie.getId(), CloudToolsForCore.getDomainId());
         BigDecimal totalPayedPrice = ProductListService.getPayedPrice(bie.getId(), bipr);
-        totalPriceToPay = totalPriceToPay.subtract(totalPayedPrice);
-        if(totalPriceToPay.compareTo(BigDecimal.ZERO) < 1) return null;
+        BigDecimal totalPriceToPay = bie.getTotalPriceVat().subtract(totalPayedPrice);
+        if (totalPriceToPay.signum() <= 0) return null;
 
-        totalPriceToPay = totalPriceToPay.setScale(2, java.math.RoundingMode.HALF_EVEN);
+        BigDecimal itemTotal = items.stream().map(item -> item.getItemPriceVatQty().setScale(2, java.math.RoundingMode.HALF_UP))
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+        if (itemTotal.compareTo(totalPriceToPay) == 0 && items.stream().allMatch(item -> item.getItemPriceVatQty().signum() >= 0)) {
+            for (BasketInvoiceItemEntity item : items) payment.addItem(basketItemToOrderItem(item));
+        }
 
         //Retrun builded payment
         return
             payment
                 .order(
                     bie.getId().toString(),
-                    bigDecimalPriceToLong( totalPriceToPay ),
-                    Currency.getByCode( BasketTools.getSystemCurrency().toUpperCase() ),
+                    exactMinorUnits(totalPriceToPay),
+                    Currency.getByCode(bie.getCurrency().toUpperCase(Locale.ROOT)),
                     paymentMethod.getFieldG()
                 ).build();
     }
@@ -253,6 +250,8 @@ public class GoPayService extends BasePaymentMethod {
         Long paymentId = Tools.getLongValue(paymentEntity.getRealPaymentId(), -1L);
         if(paymentId < 1) return new RefundationState(RefundationStatus.ERROR, REFUNDATION_FAILED);
 
+        Long refundAmountLong = exactMinorUnits(refundAmount);
+
         PaymentMethodRepository pmr = Tools.getSpringBean(PAYMENT_METHOD_REPOSITORY, PaymentMethodRepository.class);
         PaymentMethodEntity paymentMethod = pmr.findByPaymentMethodNameAndDomainId(this.getClass().getName(), CloudToolsForCore.getDomainId());
         if(paymentMethod == null) {
@@ -275,7 +274,6 @@ public class GoPayService extends BasePaymentMethod {
             if(sessionState == SessionState.PAID || sessionState == SessionState.PARTIALLY_REFUNDED) {
 
                 Long availableAmount = payment.getAmount();
-                Long refundAmountLong = bigDecimalPriceToLong(refundAmount);
 
                 if(availableAmount < refundAmountLong) {
                     adminLogError("Refund amount is higher than available amount.", request);
@@ -320,18 +318,25 @@ public class GoPayService extends BasePaymentMethod {
     }
 
     // SUPPORT THINGS
-    private final OrderItem basketItemToOrderItem(BasketInvoiceItemEntity item) {
+    private static OrderItem basketItemToOrderItem(BasketInvoiceItemEntity item) {
         OrderItem orderItem = new OrderItem();
         orderItem.setName(item.getTitle());
-        orderItem.setAmount( item.getItemPrice().longValue() );
+        orderItem.setAmount(exactMinorUnits(item.getItemPriceVatQty().setScale(2, java.math.RoundingMode.HALF_UP)));
         orderItem.setVatRate(item.getItemVat());
         orderItem.setCount( item.getItemQty().longValue() );
         orderItem.setItemType( ItemType.ITEM );
         return orderItem;
     }
 
-    private final Long bigDecimalPriceToLong(BigDecimal price) {
-        return price.multiply(new BigDecimal(100)).longValue();
+    /**
+     * Converts a finalized EUR or CZK amount to minor units without further rounding.
+     *
+     * @param price finalized payment or line amount
+     * @return exact amount in cents or halere
+     * @throws ArithmeticException if the amount has fractional minor units or exceeds a long
+     */
+    static long exactMinorUnits(BigDecimal price) {
+        return price.movePointRight(2).longValueExact();
     }
 
     @Override

--- a/src/main/java/sk/iway/iwcm/components/basket/payment_methods/rest/PaymentMethodsService.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/payment_methods/rest/PaymentMethodsService.java
@@ -2,10 +2,12 @@ package sk.iway.iwcm.components.basket.payment_methods.rest;
 
 import java.lang.reflect.Constructor;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -19,6 +21,7 @@ import sk.iway.iwcm.components.basket.jpa.BasketInvoiceItemEntity;
 import sk.iway.iwcm.components.basket.jpa.BasketInvoiceItemsRepository;
 import sk.iway.iwcm.components.basket.jpa.BasketInvoicePaymentEntity;
 import sk.iway.iwcm.components.basket.jpa.BasketInvoicePaymentsRepository;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoicesRepository;
 import sk.iway.iwcm.components.basket.jpa.InvoicePaymentStatus;
 import sk.iway.iwcm.components.basket.payment_methods.jpa.PaymentMethodEntity;
 import sk.iway.iwcm.components.basket.payment_methods.jpa.PaymentMethodRepository;
@@ -38,6 +41,8 @@ import sk.iway.iwcm.system.datatable.json.LabelValue;
  */
 @Service
 public class PaymentMethodsService {
+
+    static final String INVALID_REFUND_AMOUNT = "components.invoice.payment_refundation.invalid_amount";
 
     private final List<BasePaymentMethod> basePaymentMethodsList;
     private final PaymentMethodRepository paymentMethodRepository;
@@ -76,12 +81,41 @@ public class PaymentMethodsService {
     }
 
     public RefundationState refundPayment(BigDecimal refundAmount, BasketInvoicePaymentEntity paymentEntity, HttpServletRequest request) {
+        BasketInvoicesRepository invoices = Tools.getSpringBean("basketInvoicesRepository", BasketInvoicesRepository.class);
+        BasketInvoiceEntity invoice = invoices.findFirstByIdAndDomainId(paymentEntity.getInvoiceId(), CloudToolsForCore.getDomainId()).orElse(null);
+        if (invoice == null) return new RefundationState(RefundationStatus.ERROR, BasePaymentMethod.REFUNDATION_FAILED);
+        BasketInvoicePaymentsRepository payments = Tools.getSpringBean("basketInvoicePaymentsRepository", BasketInvoicePaymentsRepository.class);
+        BasketInvoicePaymentEntity original = payments.findById(paymentEntity.getId()).orElse(null);
+        if (original == null || !Objects.equals(invoice.getId(), original.getInvoiceId())) {
+            return new RefundationState(RefundationStatus.ERROR, BasePaymentMethod.REFUNDATION_FAILED);
+        }
+        paymentEntity = original;
         //Check that payment is NOT REFUNDATION (refundation have negative price)
         if(paymentEntity.getPayedPrice().signum() == -1) return new RefundationState(RefundationStatus.ERROR, BasePaymentMethod.CANT_REFUND_REFUNDATION, null);
         //Check refundation amount
         if(refundAmount.signum() <= 0) return new RefundationState(RefundationStatus.ERROR, BasePaymentMethod.REFUNDATION_AMOUNT_TOO_LOW, null);
         //Check that payment is confirmed
         if(Tools.isFalse(paymentEntity.getConfirmed())) return new RefundationState(RefundationStatus.ERROR, BasePaymentMethod.CANT_REFUND_NOT_CONFIRMED, null);
+
+        try {
+            refundAmount = refundAmount.setScale(2, RoundingMode.UNNECESSARY);
+            refundAmount.movePointRight(2).longValueExact();
+        } catch (ArithmeticException ex) {
+            return new RefundationState(RefundationStatus.ERROR, INVALID_REFUND_AMOUNT);
+        }
+        BigDecimal invoiceAvailable = BigDecimal.ZERO;
+        BigDecimal paymentAvailable = paymentEntity.getPayedPrice();
+        for (BasketInvoicePaymentEntity confirmed : payments.findAllByInvoiceIdAndConfirmedTrue(invoice.getId())) {
+            invoiceAvailable = invoiceAvailable.add(confirmed.getPayedPrice());
+            if (confirmed.getPayedPrice().signum() < 0 && paymentEntity.getRealPaymentId() != null
+                && Objects.equals(paymentEntity.getRealPaymentId(), confirmed.getRealPaymentId())
+                && Objects.equals(paymentEntity.getPaymentMethod(), confirmed.getPaymentMethod())) {
+                paymentAvailable = paymentAvailable.add(confirmed.getPayedPrice());
+            }
+        }
+        if (refundAmount.compareTo(invoiceAvailable) > 0 || refundAmount.compareTo(paymentAvailable) > 0) {
+            return new RefundationState(RefundationStatus.ERROR, BasePaymentMethod.REFUNDATION_AMOUNT_TOO_HIGH);
+        }
 
         BasePaymentMethod paymentMethod = null;
         for(BasePaymentMethod bpm : basePaymentMethodsList) {
@@ -121,16 +155,15 @@ public class PaymentMethodsService {
                 refundation.setPaymentStatus( InvoicePaymentStatus.REFUND_FAIL.getCode() );
             }
 
-            BasketInvoicePaymentsRepository bpr = Tools.getSpringBean("basketInvoicePaymentsRepository", BasketInvoicePaymentsRepository.class);
-            bpr.save(refundation);
+            payments.save(refundation);
 
             if(status == RefundationStatus.SUCCESS) {
                 //Update invoice status
-                ProductListService.updateInvoiceStats(paymentEntity.getInvoiceId(), true);
+                ProductListService.updatePaymentStatus(paymentEntity.getInvoiceId(), true);
 
                 //Update status of refunded payment
                 paymentEntity.setPaymentStatus( result.getStatusAfterRefund().getCode() );
-                bpr.save(paymentEntity);
+                payments.save(paymentEntity);
             }
         }
 
@@ -276,7 +309,7 @@ public class PaymentMethodsService {
             //If payment was successful
             if(status == PaymentStatus.SUCCESS) {
                 //Update invoice stats
-                ProductListService.updateInvoiceStats(bipe.getInvoiceId(), true);
+                ProductListService.updatePaymentStatus(bipe.getInvoiceId(), true);
             }
 
             return paymentState;

--- a/src/main/java/sk/iway/iwcm/components/basket/rest/BasketInvoiceItemRestController.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/rest/BasketInvoiceItemRestController.java
@@ -53,6 +53,14 @@ public class BasketInvoiceItemRestController extends DatatableRestControllerV2<B
 
         Page<BasketInvoiceItemEntity> page = basketInvoiceItemsRepository.findAllByInvoiceIdAndDomainId(invoiceId, CloudToolsForCore.getDomainId(), pageable);
 
+        if (BasketPricingService.isEnabled()) {
+            List<BasketInvoiceItemEntity> invoiceItems = basketInvoiceItemsRepository.findAllByInvoiceIdAndDomainId(invoiceId, CloudToolsForCore.getDomainId());
+            BasketPricingService.allocateVat(invoiceItems);
+            java.util.Map<Long, BasketInvoiceItemEntity> calculated = invoiceItems.stream()
+                .collect(java.util.stream.Collectors.toMap(BasketInvoiceItemEntity::getId, item -> item));
+            page = page.map(item -> calculated.get(item.getId()));
+        }
+
         paymentMethods = pms.getPaymentOptions(getProp());
         deliveryMethods = dms.getDeliveryOptions(getProp());
 
@@ -62,7 +70,7 @@ public class BasketInvoiceItemRestController extends DatatableRestControllerV2<B
 
     @Override
     public BasketInvoiceItemEntity processFromEntity(BasketInvoiceItemEntity entity, ProcessItemAction action) {
-        if(entity.getEditorFields() == null) {
+        if(entity.getEditorFields() == null || action == ProcessItemAction.EDIT) {
            BasketInvoiceItemEditorFields biief = new BasketInvoiceItemEditorFields();
            biief.fromBasketInvoiceItem(entity, paymentMethods, deliveryMethods);
         }
@@ -76,6 +84,15 @@ public class BasketInvoiceItemRestController extends DatatableRestControllerV2<B
     }
 
     @Override
+    public BasketInvoiceItemEntity processToEntity(BasketInvoiceItemEntity entity, ProcessItemAction action) {
+        if (BasketPricingService.isEnabled()) {
+            BasketPricingService.recalculateLinePrice(entity);
+            BasketPricingService.prepareForSave(entity);
+        }
+        return entity;
+    }
+
+    @Override
     public void beforeDuplicate(BasketInvoiceItemEntity entity) {
         throwError(getProp().getText("config.not_permitted_action_err"));
     }
@@ -84,12 +101,14 @@ public class BasketInvoiceItemRestController extends DatatableRestControllerV2<B
     public void afterSave(BasketInvoiceItemEntity entity, BasketInvoiceItemEntity saved) {
         //Update invoice stats
         ProductListService.updateInvoiceStats(Long.valueOf(entity.getInvoiceId()), true);
+        setForceReload(true);
     }
 
     @Override
     public void afterDelete(BasketInvoiceItemEntity entity, long id) {
         //Update invoice stats
         ProductListService.updateInvoiceStats(Long.valueOf(entity.getInvoiceId()), true);
+        setForceReload(true);
     }
 
     @Override

--- a/src/main/java/sk/iway/iwcm/components/basket/rest/BasketInvoicePaymentRestController.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/rest/BasketInvoicePaymentRestController.java
@@ -149,13 +149,13 @@ public class BasketInvoicePaymentRestController extends DatatableRestControllerV
     @Override
     public void afterSave(BasketInvoicePaymentEntity entity, BasketInvoicePaymentEntity saved) {
         //After save we need to update invoice status
-        ProductListService.updateInvoiceStats(entity.getInvoiceId(), true);
+        ProductListService.updatePaymentStatus(entity.getInvoiceId(), true);
     }
 
     @Override
     public void afterDelete(BasketInvoicePaymentEntity entity, long id) {
         //After delete we need to update invoice status
-        ProductListService.updateInvoiceStats(entity.getInvoiceId(), true);
+        ProductListService.updatePaymentStatus(entity.getInvoiceId(), true);
     }
 
     private final long getInvoiceId() {

--- a/src/main/java/sk/iway/iwcm/components/basket/rest/BasketInvoiceRestController.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/rest/BasketInvoiceRestController.java
@@ -164,7 +164,7 @@ public class BasketInvoiceRestController extends DatatableRestControllerV2<Baske
     @Override
     public void afterSave(BasketInvoiceEntity entity, BasketInvoiceEntity saved) {
         //Update invoice stats
-        ProductListService.updateInvoiceStats(entity.getId(), false);
+        ProductListService.updatePaymentStatus(entity.getId(), false);
 
         BasketInvoiceEditorFields bied = entity.getEditorFields();
         if(bied != null && Boolean.TRUE.equals(bied.getSendNotification())) {

--- a/src/main/java/sk/iway/iwcm/components/basket/rest/BasketPricingService.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/rest/BasketPricingService.java
@@ -1,0 +1,118 @@
+package sk.iway.iwcm.components.basket.rest;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.AttributedCharacterIterator;
+import java.text.CharacterIterator;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import sk.iway.iwcm.Constants;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoiceItemEntity;
+
+/**
+ * Calculates rounded gross unit prices and allocates VAT rounded per tax rate.
+ */
+public final class BasketPricingService {
+
+    private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
+
+    private BasketPricingService() {}
+
+    public static boolean isEnabled() {
+        return Constants.getBoolean("basketRoundPrices");
+    }
+
+    /** Creates a validated currency formatter shared by pricing and presentation. */
+    public static DecimalFormat createPriceFormat() {
+        String format = Constants.getString("currencyFormat");
+        if (format == null || format.isBlank() || format.length() > 255) throw new IllegalArgumentException("Currency format must contain 1 to 255 characters.");
+        DecimalFormat formatter = new DecimalFormat(format);
+        if (formatter.getMultiplier() != 1) throw new IllegalArgumentException("Currency format must not multiply basket prices.");
+        AttributedCharacterIterator output = formatter.formatToCharacterIterator(BigDecimal.ONE);
+        for (char character = output.first(); character != CharacterIterator.DONE; character = output.next()) {
+            if (output.getAttribute(NumberFormat.Field.EXPONENT) != null) throw new IllegalArgumentException("Currency format must not use scientific notation for basket prices.");
+        }
+        int scale = formatter.getMaximumFractionDigits();
+        if (scale > 18) throw new IllegalArgumentException("Currency format supports at most 18 fraction digits for basket prices.");
+        return formatter;
+    }
+
+    /** Rounds a selling unit price to the current display format's maximum precision. */
+    public static BigDecimal roundGross(BigDecimal amount) {
+        return amount.setScale(createPriceFormat().getMaximumFractionDigits(), RoundingMode.HALF_UP);
+    }
+
+    /** Applies VAT and the active selling-price policy to catalog or basket net prices. */
+    public static BigDecimal sellingPriceWithVat(BigDecimal net, BigDecimal rate) {
+        BigDecimal gross = net.multiply(rate.divide(HUNDRED).add(BigDecimal.ONE));
+        return isEnabled() ? roundGross(gross) : gross;
+    }
+
+    /** Settles a line in EUR or CZK after multiplying its rounded unit price by quantity. */
+    public static BigDecimal roundLineGross(BigDecimal grossUnit, int quantity) {
+        return grossUnit.multiply(BigDecimal.valueOf(quantity)).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    /** Calculates an item's gross unit price in memory after a net price or VAT change. */
+    public static void recalculateLinePrice(BasketInvoiceItemEntity item) {
+        recalculateLinePrice(item, createPriceFormat().getMaximumFractionDigits());
+    }
+
+    public static void recalculateLinePrice(BasketInvoiceItemEntity item, int scale) {
+        item.setRoundedUnitPriceVat(item.getItemPrice().multiply(HUNDRED.add(BigDecimal.valueOf(item.getItemVat())))
+            .movePointLeft(2).setScale(scale, RoundingMode.HALF_UP));
+        item.setLineVatAmount(null);
+    }
+
+    /** Stores the net equivalent of the agreed gross unit in the existing price column. */
+    public static void prepareForSave(BasketInvoiceItemEntity item) {
+        BigDecimal gross = item.getRoundedUnitPriceVat();
+        item.setItemPrice(gross.multiply(HUNDRED).divide(HUNDRED.add(BigDecimal.valueOf(item.getItemVat())),
+            Math.max(12, gross.scale() + 8), RoundingMode.HALF_UP));
+    }
+
+    /** Allocates each rate's rounded VAT across its lines using largest remainders. */
+    public static void allocateVat(List<BasketInvoiceItemEntity> items) {
+        Map<Integer, List<VatShare>> groups = new LinkedHashMap<>();
+        for (BasketInvoiceItemEntity item : items) {
+            if (!item.hasRoundedPrice()) recalculateLinePrice(item);
+            int rate = item.getItemVat();
+            if (rate < 0) throw new IllegalArgumentException("VAT rate must not be negative.");
+            BigDecimal numerator = item.getItemPriceVatQty().multiply(BigDecimal.valueOf(rate));
+            BigDecimal denominator = BigDecimal.valueOf(100L + rate);
+            BigDecimal floorTax = numerator.divide(denominator, 2, RoundingMode.FLOOR);
+            BigDecimal remainder = numerator.subtract(floorTax.multiply(denominator));
+            groups.computeIfAbsent(rate, ignored -> new ArrayList<>())
+                .add(new VatShare(item, numerator, floorTax, remainder));
+        }
+
+        Comparator<VatShare> allocationOrder = Comparator.comparing(VatShare::remainder).reversed()
+            .thenComparing(share -> share.item().getId(), Comparator.nullsLast(Comparator.naturalOrder()));
+        for (Map.Entry<Integer, List<VatShare>> group : groups.entrySet()) {
+            List<VatShare> shares = group.getValue();
+            BigDecimal totalNumerator = BigDecimal.ZERO;
+            BigDecimal allocatedTax = BigDecimal.ZERO;
+            for (VatShare share : shares) {
+                totalNumerator = totalNumerator.add(share.numerator());
+                allocatedTax = allocatedTax.add(share.floorTax());
+            }
+            BigDecimal targetTax = totalNumerator.divide(BigDecimal.valueOf(100L + group.getKey()), 2, RoundingMode.HALF_UP);
+            int remainingCents = targetTax.subtract(allocatedTax).movePointRight(2).intValueExact();
+            shares.sort(allocationOrder);
+            for (int index = 0; index < shares.size(); index++) {
+                VatShare share = shares.get(index);
+                BigDecimal tax = share.floorTax();
+                if (index < remainingCents) tax = tax.add(new BigDecimal("0.01"));
+                share.item().setLineVatAmount(tax);
+            }
+        }
+    }
+
+    private record VatShare(BasketInvoiceItemEntity item, BigDecimal numerator, BigDecimal floorTax, BigDecimal remainder) {}
+}

--- a/src/main/java/sk/iway/iwcm/components/basket/rest/EshopService.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/rest/EshopService.java
@@ -4,13 +4,19 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.io.Serializable;
 
 import jakarta.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.BeanWrapperImpl;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import sk.iway.iwcm.Adminlog;
 import sk.iway.iwcm.Constants;
@@ -49,6 +55,7 @@ public class EshopService {
 	private static final String BROWSER_ID_SESSION_KEY = "BasketDB.browserIdSession";
 	private static final String BASKET_ITEM_ID = "basketItemId";
 	private static final String BASKET_QTY = "basketQty";
+	private static final String PRICE_OVERRIDES = "basket.priceOverrides";
 
 	private final BasketInvoicesRepository bir;
     private final BasketInvoiceItemsRepository biir;
@@ -101,7 +108,38 @@ public class EshopService {
 	 */
 	public List<BasketInvoiceItemEntity> getBasketItems(HttpServletRequest request)
 	{
-		return biir.findAllByBrowserIdAndItemsBasketInvoiceNullAndDomainId(EshopService.getBrowserId(request), CloudToolsForCore.getDomainId());
+		List<BasketInvoiceItemEntity> originals = biir.findAllByBrowserIdAndItemsBasketInvoiceNullAndDomainId(getBrowserId(request), CloudToolsForCore.getDomainId());
+		if (!BasketPricingService.isEnabled()) return originals;
+		String currency = getDisplayCurrency(request);
+		int scale = BasketPricingService.createPriceFormat().getMaximumFractionDigits();
+		List<BasketInvoiceItemEntity> items = new ArrayList<>();
+		for (BasketInvoiceItemEntity original : originals) {
+			BasketInvoiceItemEntity item = new BasketInvoiceItemEntity();
+			BeanUtils.copyProperties(original, item, "doc", "editorFields", "itemsBasketInvoice");
+			if (original.getItemIdInt() > 0) {
+				DocDetails doc = original.getDoc();
+				if (doc == null) throw new IllegalStateException("A basket product is no longer available.");
+				item.setDoc(doc);
+				item.setItemTitle(doc.getTitle());
+				PriceOverride override = getPriceOverrides(request).get(original.getId());
+				BigDecimal net = override != null && override.net() != null ? override.net() : doc.getPrice(request);
+				BigDecimal vat = override != null && override.vat() != null ? override.vat() : doc.getVat();
+				item.setItemPrice(BasketTools.convertCurrency(net, doc.getCurrency(), currency));
+				item.setItemVat(vat.intValueExact());
+			}
+			BasketPricingService.recalculateLinePrice(item, scale);
+			items.add(item);
+		}
+		BasketPricingService.allocateVat(items);
+		return items;
+	}
+
+	private record PriceOverride(BigDecimal net, BigDecimal vat) implements Serializable { }
+
+	@SuppressWarnings("unchecked")
+	private Map<Long, PriceOverride> getPriceOverrides(HttpServletRequest request) {
+		Object stored = request.getSession().getAttribute(PRICE_OVERRIDES);
+		return stored instanceof Map ? (Map<Long, PriceOverride>) stored : Map.of();
 	}
 
 	/**
@@ -235,7 +273,25 @@ public class EshopService {
         return bir.save(basketInvoice);
     }
 
-    public BasketInvoiceEntity saveOrder(HttpServletRequest request)
+    public BasketInvoiceEntity saveOrder(HttpServletRequest request) {
+		if (!BasketPricingService.isEnabled()) return createOrder(request);
+		synchronized (request.getSession()) {
+			try {
+				TransactionTemplate transaction = new TransactionTemplate(Tools.getSpringBean("webjet2022TransactionManager", PlatformTransactionManager.class));
+				BasketInvoiceEntity invoice = transaction.execute(status -> createOrder(request));
+				if (invoice != null) {
+					request.getSession().removeAttribute(BROWSER_ID_SESSION_KEY);
+					request.getSession().removeAttribute(PRICE_OVERRIDES);
+				}
+				return invoice;
+			} catch (Exception ex) {
+				Logger.error(EshopService.class, ex);
+				return null;
+			}
+		}
+	}
+
+    private BasketInvoiceEntity createOrder(HttpServletRequest request)
 	{
 		BasketInvoiceEntity invoice = null;
 
@@ -243,7 +299,11 @@ public class EshopService {
 			invoice = new BasketInvoiceEntity();
 
 			BeanWrapperImpl wrapper = new BeanWrapperImpl(invoice);
-			wrapper.setPropertyValues(new MutablePropertyValues(request.getParameterMap()), true, true);
+			Map<String, String[]> fields = new HashMap<>(request.getParameterMap());
+			if (BasketPricingService.isEnabled()) fields.keySet().removeIf(key ->
+				!key.startsWith("contact") && !key.startsWith("delivery") && !"userNote".equals(key) && !"paymentMethod".equals(key));
+			wrapper.setPropertyValues(new MutablePropertyValues(fields), true, true);
+			invoice.setPriceToPayVat(null);
 
 			long browserId = EshopService.getBrowserId(request);
 			int userId = Tools.getUserId(request);
@@ -256,15 +316,28 @@ public class EshopService {
 			invoice.setUserLng(PageLng.getUserLng(request));
 
 			int deliveryMethodId = Tools.getIntValue(request.getParameter("deliveryMethod"),-1);
+			String country = Tools.isEmpty(request.getParameter("deliveryCountry")) ? request.getParameter("contactCountry") : request.getParameter("deliveryCountry");
 			if(deliveryMethodId > 0) {
 				try {
 					DeliveryMethodEntity dme = dms.getDeliveryMethod(deliveryMethodId, null, Prop.getInstance(request));
+					if (BasketPricingService.isEnabled() && !dme.getSupportedCountriesList().contains(country))
+						throw new IllegalArgumentException("Delivery is unavailable.");
 					String title = dme.getTitle();
 					if (Tools.isEmpty(title)) title = dme.getDeliveryMethodName();
 					invoice.setDeliveryMethod(title);
+					if (BasketPricingService.isEnabled()) saveDeliveryMethod(request, dme, Prop.getInstance(request));
 				} catch(Exception e) {
+					if (BasketPricingService.isEnabled()) throw e;
 					Logger.error(e);
 				}
+			}
+
+			if (BasketPricingService.isEnabled()) {
+				if (!List.of("eur", "czk").contains(invoice.getCurrency())) throw new IllegalStateException("Rounded checkout supports EUR and CZK.");
+				if (deliveryMethodId <= 0 && !dms.getAllDeliveryMethods(request, Prop.getInstance(request), country).isEmpty())
+					throw new IllegalArgumentException("Select a delivery method.");
+				if (!PaymentMethodsService.isPaymentMethodConfigured(invoice.getPaymentMethod(), request, Prop.getInstance(request)))
+					throw new IllegalArgumentException("Select a payment method.");
 			}
 
 			//Get all items for adminlog
@@ -272,9 +345,21 @@ public class EshopService {
 
 			//Add payment as basket item, if created add it to list
 			int newItemId = PaymentMethodsService.createPaymentInvoiceItemAndReturnId(invoice, request, biir);
+			if (BasketPricingService.isEnabled() && newItemId < 0) throw new IllegalStateException("Payment fee could not be resolved.");
 			if(newItemId != -1) {
 				BasketInvoiceItemEntity newBasketItem = getBasketItemById(newItemId);
 				basketItems.add( newBasketItem );
+			}
+
+			if (BasketPricingService.isEnabled()) {
+				basketItems = getBasketItems(request);
+				if (basketItems.stream().noneMatch(item -> item.getItemIdInt() > 0)) throw new IllegalStateException("The basket is empty.");
+				for (BasketInvoiceItemEntity item : basketItems) BasketPricingService.prepareForSave(item);
+				invoice.setPriceToPayVat(getTotalLocalPriceVat(basketItems, request));
+				invoice.setPriceToPayNoVat(getTotalLocalPrice(basketItems, request));
+				invoice.setBalanceToPay(invoice.getPriceToPayVat());
+				invoice.setItemQty(basketItems.stream().mapToInt(BasketInvoiceItemEntity::getItemQty).sum());
+				if (invoice.getPriceToPayVat().signum() <= 0) throw new IllegalStateException("The order total must be positive.");
 			}
 
 			//Save invoice
@@ -283,13 +368,15 @@ public class EshopService {
 			//Check and logs
 			if(invoice.getBasketInvoiceId() > 1)
 			{
+				if (BasketPricingService.isEnabled()) {
+					for (BasketInvoiceItemEntity item : basketItems) item.setInvoiceId(invoice.getId().intValue());
+					biir.saveAll(basketItems);
+				} else bindItemsToInvoice(invoice.getId(), invoice.getBrowserId());
 				Adminlog.add(Adminlog.TYPE_BASKET_CREATE, "Vytvorena objednavka: " + StringUtils.join(basketItems.iterator(), ","), invoice.getBasketInvoiceId(), -1);
 				Logger.println(EshopService.class, "Objednavka ulozena, id= " + invoice.getBasketInvoiceId());
 				//zrus browserId
-				request.getSession().removeAttribute(BROWSER_ID_SESSION_KEY);
+				if (!BasketPricingService.isEnabled()) request.getSession().removeAttribute(BROWSER_ID_SESSION_KEY);
 
-				//Bind items to new invoice
-				bindItemsToInvoice(invoice.getId(), invoice.getBrowserId());
 			}
 			else
 			{
@@ -298,6 +385,7 @@ public class EshopService {
 			}
 		}
 		catch (Exception e) {
+			if (BasketPricingService.isEnabled()) throw new IllegalStateException("Could not save the rounded order.", e);
 			sk.iway.iwcm.Logger.error(e);
 			invoice = null;
 		}
@@ -425,12 +513,12 @@ public class EshopService {
 	}
 
 	public boolean addDeliveryMethod(HttpServletRequest request, int deliveryMethodId, Prop prop) {
-		int itemId = Tools.getIntValue(deliveryMethodId, -1);
-		if (itemId == -1)
-			return false;
+		if (BasketPricingService.isEnabled()) return deliveryMethodId > 0;
+		if (deliveryMethodId == -1) return false;
+		return saveDeliveryMethod(request, dms.getDeliveryMethod(deliveryMethodId, null, prop), prop);
+	}
 
-		DeliveryMethodEntity dme = dms.getDeliveryMethod(deliveryMethodId, null, prop);
-
+	private boolean saveDeliveryMethod(HttpServletRequest request, DeliveryMethodEntity dme, Prop prop) {
 		long browserId = getBrowserId(request);
 		int userId = Tools.getUserId(request);
 
@@ -450,7 +538,7 @@ public class EshopService {
 		//nastavime domainId - v podstate mozeme vlozit cokolvek, setter je preimplementovany a vzdy sa vlozi aktualna domena.
 		basketItem.setDomainId(CloudToolsForCore.getDomainId());
 
-		basketItem.setItemsBasketInvoice( EshopService.getInstance().getInvoiceById(-1) );
+		basketItem.setItemsBasketInvoice( getInvoiceById(-1) );
 
 		basketItem.setItemTitle( DeliveryMethodsService.getDeliveryMethodLabel(dme.getDeliveryMethodName(), dme.getTitle(), request) );
 		basketItem.setItemPartNo(null);
@@ -585,6 +673,13 @@ public class EshopService {
 			}
 
 			saveBasketItem(basketItem);
+			if (BasketPricingService.isEnabled() && (request.getAttribute("docPrice") != null || request.getAttribute("docVat") != null)) {
+				Map<Long, PriceOverride> overrides = new HashMap<>(getPriceOverrides(request));
+				overrides.put(basketItem.getId(), new PriceOverride(
+					request.getAttribute("docPrice") == null ? null : Tools.getBigDecimalValue(request.getAttribute("docPrice"), "0"),
+					request.getAttribute("docVat") == null ? null : Tools.getBigDecimalValue(request.getAttribute("docVat"), "0")));
+				request.getSession().setAttribute(PRICE_OVERRIDES, overrides);
+			}
 			ok = true;
 		}
 
@@ -669,6 +764,7 @@ public class EshopService {
      */
     public static String getDisplayCurrency(HttpServletRequest request)
     {
+		if (BasketPricingService.isEnabled()) return BasketTools.getSystemCurrency();
         String curr = "";
         if("cloud".equals(Constants.getInstallName()))
         {

--- a/src/main/java/sk/iway/iwcm/components/basket/rest/ProductListService.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/rest/ProductListService.java
@@ -405,6 +405,10 @@ public class ProductListService {
         else
             invoiceItems = biir.findAllByInvoiceIdAndDomainId(invoiceId, domainId);
 
+        if (BasketPricingService.isEnabled()) {
+            BasketPricingService.allocateVat(invoiceItems);
+        }
+
         Integer itemsCount = 0;
         BigDecimal priceToPayNoVat = BigDecimal.ZERO; //NO VAT
         BigDecimal priceToPayVat = BigDecimal.ZERO; //WITH VAT
@@ -424,14 +428,26 @@ public class ProductListService {
         if(updateStatus) {
             //SAME time, it can change the status of invoice
             BigDecimal totalPayedPrice = getPayedPrice(invoice.getId(), bipr);
-            invoice.setStatusId( ProductListService.getInvoiceStatusByValues(priceToPayVat, totalPayedPrice) );
+            invoice.setStatusId( ProductListService.getInvoiceStatusByValues(priceToPayVat, totalPayedPrice, BasketPricingService.isEnabled()) );
         }
 
         bir.save(invoice);
     }
 
+    /** Updates payment balance and status without recalculating the agreed invoice totals. */
+    public static void updatePaymentStatus(Long invoiceId, boolean updateStatus) {
+        BasketInvoicesRepository invoices = Tools.getSpringBean("basketInvoicesRepository", BasketInvoicesRepository.class);
+        BasketInvoicePaymentsRepository payments = Tools.getSpringBean("basketInvoicePaymentsRepository", BasketInvoicePaymentsRepository.class);
+        BasketInvoiceEntity invoice = invoices.findFirstByIdAndDomainId(invoiceId, CloudToolsForCore.getDomainId()).orElse(null);
+        if (invoice == null) return;
+        BigDecimal paid = getPayedPrice(invoiceId, payments);
+        invoice.setBalanceToPay(invoice.getTotalPriceVat().subtract(paid));
+        if (updateStatus) invoice.setStatusId(getInvoiceStatusByValues(invoice.getTotalPriceVat(), paid, true));
+        invoices.save(invoice);
+    }
+
     /**
-     * Calculates the VAT-inclusive total price of all items in an invoice.
+     * Returns the stored invoice total, independent of current pricing settings.
      *
      * @param invoiceId  invoice identifier
      * @param biir  invoice item repository
@@ -439,14 +455,9 @@ public class ProductListService {
      */
     public static BigDecimal getPriceToPay(Long invoiceId, BasketInvoiceItemsRepository biir) {
         if(invoiceId == null || invoiceId < 0) return new BigDecimal(-1);
-
-        List<BasketInvoiceItemEntity> invoiceItems = biir.findAllByInvoiceIdAndDomainId(invoiceId, CloudToolsForCore.getDomainId());
-        if(invoiceItems == null || invoiceItems.isEmpty()) return BigDecimal.ZERO;
-
-        return invoiceItems.stream()
-                           .map(item -> item.getItemPriceVatQty())
-                           .reduce(BigDecimal.ZERO, BigDecimal::add)
-                           .setScale(2, RoundingMode.HALF_UP);
+        BasketInvoicesRepository invoices = Tools.getSpringBean("basketInvoicesRepository", BasketInvoicesRepository.class);
+        return invoices.findFirstByIdAndDomainId(invoiceId, CloudToolsForCore.getDomainId())
+            .map(BasketInvoiceEntity::getTotalPriceVat).orElse(BigDecimal.ZERO);
     }
 
     /**
@@ -479,13 +490,13 @@ public class ProductListService {
     public static Map<String, String> getPriceInfo(Long invoiceId, BasketInvoiceItemsRepository biir, BasketInvoicePaymentsRepository bipr) {
         BigDecimal priceToPay = getPriceToPay(invoiceId, biir);
         BigDecimal payedPrice = getPayedPrice(invoiceId, bipr);
-        int status = getInvoiceStatusByValues(priceToPay, payedPrice);
+        int status = getInvoiceStatusByValues(priceToPay, payedPrice, true);
         return Map.of(
             "priceToPay", priceToPay.toString(),
             "payedPrice", payedPrice.toString(),
             "status", String.valueOf(status)
         );
-        }
+    }
 
     /**
      * Derives an invoice status by comparing its total price with received payments.
@@ -495,7 +506,21 @@ public class ProductListService {
      * @return paid, partially paid, or new invoice status identifier
      */
     public static final Integer getInvoiceStatusByValues(BigDecimal priceToPayVat, BigDecimal totalPayedPrice) {
-        if(CurrencyTag.formatNumber(priceToPayVat).equals(CurrencyTag.formatNumber(totalPayedPrice)))
+        return getInvoiceStatusByValues(priceToPayVat, totalPayedPrice, false);
+    }
+
+    /**
+     * Compares rounded invoice amounts exactly while retaining the legacy display-based comparison.
+     *
+     * @param priceToPayVat VAT-inclusive invoice total
+     * @param totalPayedPrice total confirmed payments
+     * @param roundedPrices whether the invoice uses exact rounded gross prices
+     * @return paid, partially paid, or new invoice status identifier
+     */
+    public static final Integer getInvoiceStatusByValues(BigDecimal priceToPayVat, BigDecimal totalPayedPrice, boolean roundedPrices) {
+        boolean paid = roundedPrices ? priceToPayVat.compareTo(totalPayedPrice) == 0
+            : CurrencyTag.formatNumber(priceToPayVat, false).equals(CurrencyTag.formatNumber(totalPayedPrice, false));
+        if(paid)
             return InvoiceStatus.INVOICE_STATUS_PAID.getValue();
         else if(totalPayedPrice.compareTo(BigDecimal.valueOf(0)) > 0)
             return InvoiceStatus.INVOICE_STATUS_PARTIALLY_PAID.getValue();
@@ -515,6 +540,9 @@ public class ProductListService {
     public static void addItemToInvoice(Long invoiceId, List<Integer> itemIdsToAdd, BasketInvoiceItemsRepository biir, int userId, HttpServletRequest request) {
 		DocDB docDB = DocDB.getInstance();
 		int domainId = CloudToolsForCore.getDomainId();
+		BasketInvoicesRepository invoices = Tools.getSpringBean("basketInvoicesRepository", BasketInvoicesRepository.class);
+		BasketInvoiceEntity invoice = invoices.findFirstByIdAndDomainId(invoiceId, domainId).orElse(null);
+		if (invoice == null) return;
 
 		Long browserId = biir.getBrowserIdByInvoiceId(invoiceId, domainId).orElse(null);
 		if(browserId == null) browserId = Long.valueOf( PkeyGenerator.getNextValue("basket_browser_id") );
@@ -544,11 +572,17 @@ public class ProductListService {
 					newItem.setDateInsert(new Date(Tools.getNow()));
 					newItem.setInvoiceId(invoiceId.intValue());
 					newItem.setDomainId(domainId);
+					if (BasketPricingService.isEnabled()) {
+						newItem.setItemPrice(BasketTools.convertCurrency(newItem.getItemPrice(), itemDoc.getCurrency(), invoice.getCurrency()));
+						BasketPricingService.recalculateLinePrice(newItem);
+						BasketPricingService.prepareForSave(newItem);
+					}
 
 					biir.save(newItem);
 				}
 
 			}
 		}
+		updateInvoiceStats(invoiceId, true);
 	}
 }

--- a/src/main/java/sk/iway/iwcm/components/basket/support/MethodDto.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/support/MethodDto.java
@@ -5,7 +5,6 @@ import java.math.BigDecimal;
 import jakarta.servlet.http.HttpServletRequest;
 
 import lombok.Data;
-import sk.iway.iwcm.common.BasketTools;
 
 /**
  * Data transfer object for delivery/payment methods
@@ -23,6 +22,6 @@ public class MethodDto {
     }
 
     public BigDecimal getLocalPriceVat(HttpServletRequest request) {
-        return BasketTools.convertToBasketDisplayCurrency(getPriceVat(), request);
+        return SupportService.getLocalPriceVat(getPriceVat(), request);
     }
 }

--- a/src/main/java/sk/iway/iwcm/components/basket/support/SupportService.java
+++ b/src/main/java/sk/iway/iwcm/components/basket/support/SupportService.java
@@ -13,6 +13,8 @@ import sk.iway.iwcm.common.BasketTools;
 import sk.iway.iwcm.components.basket.delivery_methods.jpa.DeliveryMethodEntity;
 import sk.iway.iwcm.editor.rest.Field;
 import sk.iway.iwcm.i18n.Prop;
+import sk.iway.iwcm.components.basket.rest.BasketPricingService;
+import sk.iway.iwcm.components.basket.rest.EshopService;
 import sk.iway.tags.CurrencyTag;
 
 public class SupportService {
@@ -61,28 +63,24 @@ public class SupportService {
     }
 
     public static final String getCustomerTitle(BigDecimal priceVat, HttpServletRequest request, Prop prop, FieldsConfig annotation) {
-        StringBuilder name = new StringBuilder();
-        name.append( prop.getText(annotation.nameKey()) ).append(": ");
-        BigDecimal convertedPrice = BasketTools.convertToBasketDisplayCurrency(priceVat, request);
-        name.append( CurrencyTag.formatNumber(convertedPrice) ).append(" ");
-        name.append( CurrencyTag.getLabelFromCurrencyCode( Constants.getString("basketDisplayCurrency") ) );
-        return name.toString();
+        return prop.getText(annotation.nameKey()) + ": " + formatPrice(priceVat, request);
     }
 
     public static final String getCustomerTitle(DeliveryMethodEntity dme, HttpServletRequest request, Prop prop, FieldsConfig annotation) {
-        StringBuilder name = new StringBuilder();
+        String title = Tools.isNotEmpty(dme.getTitle()) ? dme.getTitle() : annotation.nameKey();
+        return prop.getText(title, false) + ": " + formatPrice(dme.getPriceVat(), request);
+    }
 
-        if (Tools.isNotEmpty(dme.getTitle())) {
-            name.append(prop.getText(dme.getTitle(), false));
-        } else {
-            name.append(prop.getText(annotation.nameKey(), false));
-        }
-        name.append(": ");
+    /** Returns the converted fee amount used by labels and fee previews. */
+    public static BigDecimal getLocalPriceVat(BigDecimal priceVat, HttpServletRequest request) {
+        BigDecimal converted = BasketTools.convertToBasketDisplayCurrency(priceVat, request);
+        return BasketPricingService.isEnabled()
+            ? BasketPricingService.roundLineGross(BasketPricingService.roundGross(converted), 1) : converted;
+    }
 
-        BigDecimal convertedPrice = BasketTools.convertToBasketDisplayCurrency(dme.getPriceVat(), request);
-        name.append( CurrencyTag.formatNumber(convertedPrice) ).append(" ");
-        name.append( CurrencyTag.getLabelFromCurrencyCode( Constants.getString("basketDisplayCurrency") ) );
-        return name.toString();
+    private static String formatPrice(BigDecimal priceVat, HttpServletRequest request) {
+        String currency = BasketPricingService.isEnabled() ? EshopService.getDisplayCurrency(request) : Constants.getString("basketDisplayCurrency");
+        return CurrencyTag.formatNumber(getLocalPriceVat(priceVat, request)) + " " + CurrencyTag.getLabelFromCurrencyCode(currency);
     }
 
     public static final String getFieldValue(SupportMethodEntity method, char fieldAlphabet) {

--- a/src/main/java/sk/iway/iwcm/doc/DocBasic.java
+++ b/src/main/java/sk/iway/iwcm/doc/DocBasic.java
@@ -27,6 +27,7 @@ import sk.iway.iwcm.*;
 import sk.iway.iwcm.common.BasketTools;
 import sk.iway.iwcm.common.GalleryToolsForCore;
 import sk.iway.iwcm.components.basket.rest.EshopService;
+import sk.iway.iwcm.components.basket.rest.BasketPricingService;
 import sk.iway.iwcm.gallery.GalleryDB;
 import sk.iway.iwcm.system.datatable.DataTableColumnType;
 import sk.iway.iwcm.system.datatable.annotations.DataTableColumn;
@@ -56,7 +57,6 @@ public class DocBasic implements DocGroupInterface, Serializable
 {
 	private static final BigDecimal VALUE_OF_MINUS_1 = new BigDecimal(-1);
 	private static final BigDecimal VALUE_OF_0 = new BigDecimal(0);
-	private static final BigDecimal VALUE_OF_1 = new BigDecimal(1);
 	private static final BigDecimal VALUE_OF_100 = new BigDecimal(100);
 
 	public enum FollowLinksMode {
@@ -926,9 +926,7 @@ public class DocBasic implements DocGroupInterface, Serializable
 	 */
 	public BigDecimal getLocalPriceVat(HttpServletRequest request)
 	{
-		BigDecimal localPrice = getLocalPrice(request);
-		//AKA (getVat / 100 + 1) * localPrice
-		return ( (getVat().divide(VALUE_OF_100)).add(VALUE_OF_1) ).multiply(localPrice);
+		return BasketPricingService.sellingPriceWithVat(getLocalPrice(request), getVat());
 	}
 
 	/**
@@ -939,9 +937,7 @@ public class DocBasic implements DocGroupInterface, Serializable
 	 */
 	public BigDecimal getLocalPriceVat(HttpServletRequest request, String currency)
 	{
-		BigDecimal localPrice = getLocalPrice(request, currency);
-		//AKA (getVat / 100 + 1) * localPrice
-		return ( ( getVat().divide(VALUE_OF_100) ).add(VALUE_OF_1) ).multiply(localPrice);
+		return BasketPricingService.sellingPriceWithVat(getLocalPrice(request, currency), getVat());
 	}
 
 	@JsonIgnore
@@ -964,19 +960,13 @@ public class DocBasic implements DocGroupInterface, Serializable
 	@JsonIgnore
 	public BigDecimal getPriceVat()
 	{
-		BigDecimal vat = getVat();
-		vat = (vat.divide(VALUE_OF_100)).add(VALUE_OF_1);
-
-		return getPrice().multiply(vat);
+		return BasketPricingService.sellingPriceWithVat(getPrice(), getVat());
 	}
 
 	@JsonIgnore
 	public BigDecimal getPriceVat(HttpServletRequest request)
 	{
-		BigDecimal vat = getVat();
-		vat = (vat.divide(VALUE_OF_100)).add(VALUE_OF_1);
-
-		return getPrice(request).multiply(vat);
+		return BasketPricingService.sellingPriceWithVat(getPrice(request), getVat());
 	}
 
 	@JsonIgnore

--- a/src/main/java/sk/iway/tags/CurrencyTag.java
+++ b/src/main/java/sk/iway/tags/CurrencyTag.java
@@ -2,6 +2,7 @@ package sk.iway.tags;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 
@@ -13,6 +14,7 @@ import org.displaytag.tags.TableTagParameters;
 
 import sk.iway.iwcm.Constants;
 import sk.iway.iwcm.Tools;
+import sk.iway.iwcm.components.basket.rest.BasketPricingService;
 
 /**
  *  Will format body of tag (number) to currency value
@@ -61,8 +63,14 @@ public class CurrencyTag extends BodyTagSupport
    @Override
 	public int doAfterBody() throws JspTagException
    {
+      boolean decimalPrices = BasketPricingService.isEnabled();
+
    	DecimalFormat formater;
-	   if(Tools.isEmpty(format))
+	   if (decimalPrices)
+	   {
+          formater = formatter(true);
+	   }
+	   else if(Tools.isEmpty(format))
 	   {
 	   	if (groupingSize > -1)
 	   	{
@@ -70,7 +78,7 @@ public class CurrencyTag extends BodyTagSupport
 	   	}
 	   	else
 	   	{
-	   		formater = nf;
+            formater = (DecimalFormat) nf.clone();
 	   	}
 	   }
 	   else
@@ -88,7 +96,7 @@ public class CurrencyTag extends BodyTagSupport
       bc.clearBody();
       //NumberFormat nf = NumberFormat.getCurrencyInstance();
 
-		if (round == null) round = Boolean.valueOf(Constants.getBoolean("currencyTagRound"));
+		boolean roundPrice = isRound();
 
 		boolean isExport = (pageContext.getRequest().getParameter(TableTagParameters.PARAMETER_EXPORTING) != null);
 
@@ -97,20 +105,27 @@ public class CurrencyTag extends BodyTagSupport
          String out = body;
          try
          {
-            double number = Double.parseDouble(body);
-
-            if (round)
+            if (decimalPrices)
             {
-            	//zaokruhli cislo
-            	int celeCislo = (int)number;
-            	double zvysok = number - celeCislo;
-
-            	if (zvysok < 0.3) number = celeCislo;
-            	else if (zvysok < 0.7) number = celeCislo + 0.5;
-            	else if (zvysok < 1) number = celeCislo + 1;
+               out = formater.format(new BigDecimal(body.trim()));
             }
+            else
+            {
+               double number = Double.parseDouble(body);
 
-            out = formater.format(number);
+               if (roundPrice)
+               {
+                  // Apply legacy rounding to whole or half currency units.
+                  int celeCislo = (int)number;
+                  double zvysok = number - celeCislo;
+
+                  if (zvysok < 0.3) number = celeCislo;
+                  else if (zvysok < 0.7) number = celeCislo + 0.5;
+                  else if (zvysok < 1) number = celeCislo + 1;
+               }
+
+               out = formater.format(number);
+            }
 
             if (Tools.isNotEmpty(currency))
             {
@@ -135,28 +150,51 @@ public class CurrencyTag extends BodyTagSupport
    }
 
    /**
-    * Naformatuje <code>double</code> cislo
-    * @param number
-    * @return
+    * Formats a price according to the active pricing policy.
+    * @param number amount to display
+    * @return localized amount without a currency label
     */
    public static String formatNumber(double number)
    {
-   	return nf.format(number);
+      return BasketPricingService.isEnabled() ? formatNumber(BigDecimal.valueOf(number)) : ((DecimalFormat) nf.clone()).format(number);
    }
 
    /**
-    * Naformatuje <code>BigDecimal</code> cislo
-    * @param number
-    * @return
+    * Formats a price according to the active pricing policy.
+    * @param number amount to display
+    * @return localized amount without a currency label
     */
    public static String formatNumber(BigDecimal number)
    {
-   	return nf.format(number);
+      return formatNumber(number, BasketPricingService.isEnabled());
+   }
+
+   /**
+    * Formats an amount using the active pattern or explicitly retains legacy formatting.
+    * @param number amount to display
+    * @param roundedPrices whether to use the active rounded price pattern
+    * @return localized amount without a currency label
+    */
+   public static String formatNumber(BigDecimal number, boolean roundedPrices)
+   {
+      return formatter(roundedPrices).format(number);
+   }
+
+   private static DecimalFormat formatter(boolean roundedPrices)
+   {
+      if (!roundedPrices) return (DecimalFormat) nf.clone();
+      DecimalFormat formatter = BasketPricingService.createPriceFormat();
+      formatter.setDecimalFormatSymbols(symbols);
+      formatter.setMinimumFractionDigits(Math.max(2, formatter.getMinimumFractionDigits()));
+      formatter.setGroupingSize(3);
+      formatter.setGroupingUsed(true);
+      formatter.setRoundingMode(RoundingMode.HALF_UP);
+      return formatter;
    }
 
    public boolean isRound()
 	{
-		return round;
+		return round != null ? round : Constants.getBoolean("currencyTagRound");
 	}
 
 	public void setRound(boolean round)
@@ -169,6 +207,9 @@ public class CurrencyTag extends BodyTagSupport
 	{
 		super.release();
 		round = null;
+		currency = null;
+		format = null;
+		groupingSize = 3;
 	}
 
 	public String getFormat() {

--- a/src/main/webapp/WEB-INF/classes/text-webjet9.properties
+++ b/src/main/webapp/WEB-INF/classes/text-webjet9.properties
@@ -3130,3 +3130,6 @@ apps.eshop.stats.statuses_selected=Vybrané stavy: {0}
 apps.eshop.stats.unknown=Neznáme
 apps.eshop.stats.load_error.title=Štatistiky sa nepodarilo načítať
 apps.eshop.stats.load_error.text=Skúste obnoviť stránku alebo zmeniť zvolený rozsah dátumov.
+
+components.basket.invoice.items.unit_price_with_vat=Jednotková cena s DPH
+components.invoice.payment_refundation.invalid_amount=Suma na vrátenie musí byť platná suma najviac s dvoma desatinnými miestami.

--- a/src/main/webapp/WEB-INF/classes/text_cz-webjet9.properties
+++ b/src/main/webapp/WEB-INF/classes/text_cz-webjet9.properties
@@ -3130,3 +3130,6 @@ apps.eshop.stats.statuses_selected=Vybrané stavy: {0}
 apps.eshop.stats.unknown=Neznámé
 apps.eshop.stats.load_error.title=Statistiky se nepodařilo načíst
 apps.eshop.stats.load_error.text=Zkuste obnovit stránku nebo změnit zvolený rozsah dat.
+
+components.basket.invoice.items.unit_price_with_vat=Jednotková cena s DPH
+components.invoice.payment_refundation.invalid_amount=Částka k vrácení musí být platná částka nejvýše se dvěma desetinnými místy.

--- a/src/main/webapp/WEB-INF/classes/text_en-webjet9.properties
+++ b/src/main/webapp/WEB-INF/classes/text_en-webjet9.properties
@@ -3130,3 +3130,6 @@ apps.eshop.stats.statuses_selected=Selected statuses: {0}
 apps.eshop.stats.unknown=Unknown
 apps.eshop.stats.load_error.title=Statistics could not be loaded
 apps.eshop.stats.load_error.text=Try refreshing the page or changing the selected date range.
+
+components.basket.invoice.items.unit_price_with_vat=Unit price including VAT
+components.invoice.payment_refundation.invalid_amount=The refund must be a valid amount with at most two decimal places.

--- a/src/test/java/sk/iway/iwcm/components/basket/payment_methods/rest/GoPayServiceTest.java
+++ b/src/test/java/sk/iway/iwcm/components/basket/payment_methods/rest/GoPayServiceTest.java
@@ -1,0 +1,85 @@
+package sk.iway.iwcm.components.basket.payment_methods.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import cz.gopay.api.v3.model.common.Currency;
+import cz.gopay.api.v3.model.payment.BasePayment;
+import sk.iway.iwcm.common.BasketTools;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoiceEntity;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoiceItemEntity;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoiceItemsRepository;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoicePaymentEntity;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoicePaymentsRepository;
+import sk.iway.iwcm.components.basket.payment_methods.jpa.PaymentMethodEntity;
+
+/** Covers the monetary contract sent to GoPay, including partial payments. */
+class GoPayServiceTest {
+
+    /** Payment attempts use stored totals and currency, then charge only the remaining balance. */
+    @Test
+    void chargesStoredInvoiceAndOutstandingBalance() {
+        try (MockedStatic<BasketTools> currencies = mockStatic(BasketTools.class)) {
+            currencies.when(BasketTools::getSystemCurrency).thenReturn("eur");
+            BasePayment full = payment("4.77", "0.00");
+            assertEquals(Currency.CZK, full.getCurrency());
+            assertEquals(477L, full.getAmount());
+            assertEquals(477L, full.getItems().get(0).getAmount());
+            assertEquals(3L, full.getItems().get(0).getCount());
+
+            BasePayment partial = payment("4.77", "1.00");
+            assertEquals(377L, partial.getAmount());
+            assertNull(partial.getItems());
+            assertNull(payment("4.77", "4.77"));
+
+            BasePayment differingBreakdown = payment("5.00", "0.00");
+            assertEquals(500L, differingBreakdown.getAmount());
+            assertNull(differingBreakdown.getItems());
+        }
+    }
+
+    /** Gateway amounts must not silently discard fractional cents or overflow. */
+    @Test
+    void convertsMinorUnitsExactly() {
+        assertEquals(159L, GoPayService.exactMinorUnits(new BigDecimal("1.5900")));
+        assertThrows(ArithmeticException.class, () -> GoPayService.exactMinorUnits(new BigDecimal("1.594")));
+        assertThrows(ArithmeticException.class, () -> GoPayService.exactMinorUnits(new BigDecimal("92233720368547758.08")));
+    }
+
+    private BasePayment payment(String total, String paid) {
+        BasketInvoiceEntity invoice = new BasketInvoiceEntity();
+        invoice.setId(10L);
+        invoice.setCurrency("czk");
+        invoice.setUserLng("en");
+        invoice.setPriceToPayVat(new BigDecimal(total));
+        BasketInvoiceItemEntity item = new BasketInvoiceItemEntity();
+        item.setInvoiceId(10);
+        item.setItemTitle("Product");
+        item.setItemPrice(new BigDecimal("1.59"));
+        item.setRoundedUnitPriceVat(new BigDecimal("1.59"));
+        item.setItemVat(0);
+        item.setItemQty(3);
+        BasketInvoiceItemsRepository items = mock(BasketInvoiceItemsRepository.class);
+        when(items.findAllByInvoiceIdAndDomainId(eq(10L), anyInt())).thenReturn(List.of(item));
+        BasketInvoicePaymentsRepository payments = mock(BasketInvoicePaymentsRepository.class);
+        BasketInvoicePaymentEntity confirmed = new BasketInvoicePaymentEntity();
+        confirmed.setPayedPrice(new BigDecimal(paid));
+        when(payments.findAllByInvoiceIdAndConfirmedTrue(10L)).thenReturn(List.of(confirmed));
+        PaymentMethodEntity method = new PaymentMethodEntity();
+        method.setFieldD("1234");
+        method.setFieldG("Test order");
+        return new GoPayService().getPayment(invoice, "https://example.test/payment", method, items, payments);
+    }
+}

--- a/src/test/java/sk/iway/iwcm/components/basket/payment_methods/rest/PaymentRefundPricingTest.java
+++ b/src/test/java/sk/iway/iwcm/components/basket/payment_methods/rest/PaymentRefundPricingTest.java
@@ -1,0 +1,102 @@
+package sk.iway.iwcm.components.basket.payment_methods.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import sk.iway.iwcm.Tools;
+import sk.iway.iwcm.common.CloudToolsForCore;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoiceEntity;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoicePaymentEntity;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoicePaymentsRepository;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoicesRepository;
+import sk.iway.iwcm.components.basket.jpa.InvoicePaymentStatus;
+import sk.iway.iwcm.components.basket.payment_methods.jpa.PaymentMethodRepository;
+import sk.iway.iwcm.components.basket.payment_methods.jpa.RefundationState;
+import sk.iway.iwcm.components.basket.payment_methods.jpa.RefundationState.RefundationStatus;
+import sk.iway.iwcm.components.basket.rest.ProductListService;
+import sk.iway.iwcm.i18n.Prop;
+
+/** Covers refund limits and exact persistence of the amount sent to the provider. */
+class PaymentRefundPricingTest {
+
+    /** Rejects invalid refunds before dispatch and persists the exact accepted remaining amount. */
+    @Test
+    void refundsOnlyTheRemainingAmountFromTheStoredPayment() {
+        BasketInvoiceEntity invoice = new BasketInvoiceEntity();
+        invoice.setId(10L);
+        BasketInvoicePaymentEntity original = payment(11L, "3.18", "123");
+        BasketInvoicePaymentEntity submitted = payment(11L, "999.99", "123");
+        List<BasketInvoicePaymentEntity> confirmed = List.of(original,
+            payment(12L, "-1.59", "123"), payment(13L, "20.00", "456"));
+        BasketInvoicesRepository invoices = mock(BasketInvoicesRepository.class);
+        BasketInvoicePaymentsRepository payments = mock(BasketInvoicePaymentsRepository.class);
+        when(invoices.findFirstByIdAndDomainId(10L, 1)).thenReturn(Optional.of(invoice));
+        when(payments.findById(11L)).thenReturn(Optional.of(original));
+        when(payments.findAllByInvoiceIdAndConfirmedTrue(10L)).thenReturn(confirmed);
+        GoPayService provider = mock(GoPayService.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        RefundationState success = new RefundationState(RefundationStatus.SUCCESS, BasePaymentMethod.REFUNDATION_SUCCESS);
+        success.setStatusAfterRefund(InvoicePaymentStatus.PARTIALLY_REFUNDED);
+        when(provider.doPaymentRefund(any(), any(), eq(request))).thenReturn(success);
+        PaymentMethodsService service = new PaymentMethodsService(List.of(provider), mock(PaymentMethodRepository.class));
+        Prop prop = mock(Prop.class);
+
+        try (MockedStatic<Tools> tools = mockStatic(Tools.class);
+             MockedStatic<CloudToolsForCore> cloud = mockStatic(CloudToolsForCore.class);
+             MockedStatic<Prop> props = mockStatic(Prop.class);
+             MockedStatic<ProductListService> pricing = mockStatic(ProductListService.class)) {
+            tools.when(() -> Tools.getSpringBean("basketInvoicesRepository", BasketInvoicesRepository.class)).thenReturn(invoices);
+            tools.when(() -> Tools.getSpringBean("basketInvoicePaymentsRepository", BasketInvoicePaymentsRepository.class)).thenReturn(payments);
+            cloud.when(CloudToolsForCore::getDomainId).thenReturn(1);
+            props.when(() -> Prop.getInstance(request)).thenReturn(prop);
+
+            RefundationState fractional = service.refundPayment(new BigDecimal("1.595"), submitted, request);
+            assertEquals(RefundationStatus.ERROR, fractional.getStatus());
+            assertEquals(PaymentMethodsService.INVALID_REFUND_AMOUNT, fractional.getMsgKey());
+            RefundationState excessive = service.refundPayment(new BigDecimal("1.60"), submitted, request);
+            assertEquals(RefundationStatus.ERROR, excessive.getStatus());
+            assertEquals(BasePaymentMethod.REFUNDATION_AMOUNT_TOO_HIGH, excessive.getMsgKey());
+            verifyNoInteractions(provider);
+            verify(payments, never()).save(any());
+            pricing.verifyNoInteractions();
+
+            RefundationState result = service.refundPayment(new BigDecimal("1.5900"), submitted, request);
+            verify(provider).doPaymentRefund(new BigDecimal("1.59"), original, request);
+            assertEquals(RefundationStatus.SUCCESS, result.getStatus());
+            ArgumentCaptor<BasketInvoicePaymentEntity> saved = ArgumentCaptor.forClass(BasketInvoicePaymentEntity.class);
+            verify(payments, times(2)).save(saved.capture());
+            assertEquals(new BigDecimal("-1.59"), saved.getAllValues().get(0).getPayedPrice());
+            assertEquals("123", saved.getAllValues().get(0).getRealPaymentId());
+            pricing.verify(() -> ProductListService.updatePaymentStatus(10L, true));
+        }
+    }
+
+    private BasketInvoicePaymentEntity payment(long id, String amount, String providerId) {
+        BasketInvoicePaymentEntity payment = new BasketInvoicePaymentEntity();
+        payment.setId(id);
+        payment.setInvoiceId(10L);
+        payment.setPayedPrice(new BigDecimal(amount));
+        payment.setConfirmed(true);
+        payment.setPaymentMethod(GoPayService.class.getName());
+        payment.setRealPaymentId(providerId);
+        return payment;
+    }
+}

--- a/src/test/java/sk/iway/iwcm/components/basket/rest/BasketPricingServiceTest.java
+++ b/src/test/java/sk/iway/iwcm/components/basket/rest/BasketPricingServiceTest.java
@@ -1,0 +1,96 @@
+package sk.iway.iwcm.components.basket.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import sk.iway.iwcm.Constants;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoiceItemEntity;
+
+/** Covers selling-unit rounding, small prices and reconciled VAT for a mixed basket. */
+class BasketPricingServiceTest {
+
+    private String originalFormat;
+
+    @BeforeEach
+    void setUp() {
+        originalFormat = Constants.getString("currencyFormat");
+        Constants.setString("currencyFormat", "0.00");
+    }
+
+    @AfterEach
+    void tearDown() {
+        Constants.setString("currencyFormat", originalFormat);
+    }
+
+    /** Half-cent ties round upwards before quantity is multiplied, without changing the source price. */
+    @ParameterizedTest
+    @CsvSource({ "1.594,1.59,4.77", "1.595,1.60,4.80", "1.585,1.59,4.77" })
+    void chargesTheRoundedUnitPrice(String source, String unit, String total) {
+        BasketInvoiceItemEntity item = item(source, 0, 3, 1);
+        BasketPricingService.allocateVat(List.of(item));
+
+        assertEquals(new BigDecimal(unit), item.getItemPriceVat());
+        assertEquals(new BigDecimal(total), item.getItemPriceVatQty());
+        assertEquals(new BigDecimal(total), item.getItemPriceQty());
+        assertEquals(new BigDecimal(source), item.getItemPrice());
+    }
+
+    /** Optional format digits preserve tiny units; line settlement and VAT reconcile after reloading existing fields. */
+    @Test
+    void preservesTinyPricesThroughQuantityAndReload() {
+        Constants.setString("currencyFormat", "0.00##");
+        BasketInvoiceItemEntity original = item("0.00008", 23, 155, 1);
+        BasketPricingService.recalculateLinePrice(original);
+        assertEquals(new BigDecimal("0.0001"), original.getItemPriceVat());
+        BasketPricingService.prepareForSave(original);
+
+        BasketInvoiceItemEntity loaded = item(BigDecimal.valueOf(original.getItemPrice().doubleValue()).toPlainString(), 23, 155, 1);
+        BasketPricingService.allocateVat(List.of(loaded));
+        assertEquals(new BigDecimal("0.0001"), loaded.getItemPriceVat());
+        assertEquals(new BigDecimal("0.02"), loaded.getItemPriceVatQty());
+        assertEquals(new BigDecimal("0.00"), loaded.getLineVatAmount());
+        assertEquals(new BigDecimal("0.02"), loaded.getItemPriceQty());
+    }
+
+    /** A basket with mixed rates and a credit allocates residual cents deterministically by remainder and item ID. */
+    @Test
+    void reconcilesMixedVatAndCreditsRegardlessOfRowOrder() {
+        BasketInvoiceItemEntity first = item("0.025", 20, 1, 1);
+        BasketInvoiceItemEntity second = item("0.025", 20, 1, 2);
+        BasketInvoiceItemEntity credit = item("-0.02", 20, 1, 3);
+        BasketInvoiceItemEntity reduced = item("10.00", 5, 2, 4);
+        BasketInvoiceItemEntity zero = item("1.594", 0, 3, 5);
+        List<BasketInvoiceItemEntity> items = new ArrayList<>(List.of(second, first, credit, reduced, zero));
+        BasketPricingService.allocateVat(items);
+        List<BigDecimal> expectedVat = List.of(new BigDecimal("0.01"), new BigDecimal("0.00"),
+            new BigDecimal("0.00"), new BigDecimal("1.00"), new BigDecimal("0.00"));
+        assertEquals(expectedVat, List.of(first, second, credit, reduced, zero).stream()
+            .map(BasketInvoiceItemEntity::getLineVatAmount).toList());
+        assertEquals(new BigDecimal("25.81"), items.stream().map(BasketInvoiceItemEntity::getItemPriceVatQty).reduce(BigDecimal.ZERO, BigDecimal::add));
+        assertEquals(new BigDecimal("24.80"), items.stream().map(BasketInvoiceItemEntity::getItemPriceQty).reduce(BigDecimal.ZERO, BigDecimal::add));
+
+        Collections.reverse(items);
+        BasketPricingService.allocateVat(items);
+        assertEquals(expectedVat, List.of(first, second, credit, reduced, zero).stream()
+            .map(BasketInvoiceItemEntity::getLineVatAmount).toList());
+    }
+
+    private BasketInvoiceItemEntity item(String net, int vat, int quantity, long id) {
+        BasketInvoiceItemEntity item = new BasketInvoiceItemEntity();
+        item.setId(id);
+        item.setItemPrice(new BigDecimal(net));
+        item.setItemVat(vat);
+        item.setItemQty(quantity);
+        return item;
+    }
+}

--- a/src/test/java/sk/iway/iwcm/components/basket/rest/EshopPricingTest.java
+++ b/src/test/java/sk/iway/iwcm/components/basket/rest/EshopPricingTest.java
@@ -1,0 +1,252 @@
+package sk.iway.iwcm.components.basket.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+import sk.iway.iwcm.Adminlog;
+import sk.iway.iwcm.Constants;
+import sk.iway.iwcm.PageLng;
+import sk.iway.iwcm.Tools;
+import sk.iway.iwcm.common.CloudToolsForCore;
+import sk.iway.iwcm.components.basket.delivery_methods.jpa.DeliveryMethodEntity;
+import sk.iway.iwcm.components.basket.delivery_methods.rest.DeliveryMethodsService;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoiceEntity;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoiceItemEntity;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoiceItemsRepository;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoicePaymentsRepository;
+import sk.iway.iwcm.components.basket.jpa.BasketInvoicesRepository;
+import sk.iway.iwcm.components.basket.payment_methods.rest.PaymentMethodsService;
+import sk.iway.iwcm.doc.DocDetails;
+import sk.iway.iwcm.i18n.Prop;
+
+/**
+ * Tests storefront repricing and checkout using only existing item and invoice columns.
+ */
+class EshopPricingTest {
+
+    private static final String PAYMENT = "test.payment";
+    private final Map<String, String> originalSettings = new HashMap<>();
+    private final List<BasketInvoiceItemEntity> originalItems = new ArrayList<>();
+    private String originalInstallName;
+    private MockHttpServletRequest request;
+    private BasketInvoicesRepository invoices;
+    private BasketInvoiceItemsRepository items;
+    private DeliveryMethodsService deliveries;
+    private DeliveryMethodEntity delivery;
+    private EshopService service;
+    private Prop prop;
+    private BigDecimal paymentNet = BigDecimal.ZERO;
+    private MockedStatic<CloudToolsForCore> cloudMock;
+    private MockedStatic<PaymentMethodsService> paymentsMock;
+    private MockedStatic<Prop> propMock;
+
+    @BeforeEach
+    void setUp() {
+        originalInstallName = Constants.getInstallName();
+        config("basketRoundPrices", "true");
+        config("currencyFormat", "0.00");
+        config("basketProductCurrency", "eur");
+        config("basketDisplayCurrency", "eur");
+        config("supportedCurrencies", "eur,czk");
+        config("constantsAliasSearch", "false");
+        config("multiDomainUseAliasAsInstallName", "false");
+        Constants.setInstallName("pricing-test");
+        request = new MockHttpServletRequest();
+        request.setMethod("POST");
+        request.getSession().setAttribute("BasketDB.browserIdSession", "100");
+        request.setParameter("deliveryMethod", "1");
+        request.setParameter("paymentMethod", PAYMENT);
+        request.setParameter("contactCountry", "sk");
+        request.setAttribute("xssTestDisabled", "true");
+
+        invoices = mock(BasketInvoicesRepository.class);
+        items = mock(BasketInvoiceItemsRepository.class);
+        deliveries = mock(DeliveryMethodsService.class);
+        service = new EshopService(invoices, items, mock(BasketInvoicePaymentsRepository.class), deliveries);
+        cloudMock = mockStatic(CloudToolsForCore.class);
+        cloudMock.when(CloudToolsForCore::getDomainId).thenReturn(1);
+        when(items.findAllByBrowserIdAndItemsBasketInvoiceNullAndDomainId(100L, 1)).thenAnswer(ignored -> originalItems);
+        when(items.save(any())).thenAnswer(call -> {
+            BasketInvoiceItemEntity saved = call.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(998L);
+                originalItems.add(saved);
+            }
+            return saved;
+        });
+
+        prop = mock(Prop.class);
+        when(prop.getText(anyString())).thenAnswer(call -> call.getArgument(0));
+        propMock = mockStatic(Prop.class);
+        propMock.when(() -> Prop.getInstance(request)).thenReturn(prop);
+        delivery = new DeliveryMethodEntity();
+        delivery.setId(1L);
+        delivery.setDeliveryMethodName("test.delivery");
+        delivery.setTitle("Delivery");
+        delivery.setPrice(BigDecimal.ZERO);
+        delivery.setVat(0);
+        delivery.setSupportedCountriesStr("sk,cz");
+        when(deliveries.getDeliveryMethod(1L, null, prop)).thenReturn(delivery);
+
+        paymentsMock = mockStatic(PaymentMethodsService.class);
+        paymentsMock.when(() -> PaymentMethodsService.isPaymentMethodConfigured(PAYMENT, request, prop)).thenReturn(true);
+        paymentsMock.when(() -> PaymentMethodsService.createPaymentInvoiceItemAndReturnId(any(BasketInvoiceEntity.class), any(), any()))
+            .thenAnswer(ignored -> {
+                BasketInvoiceItemEntity fee = fee();
+                fee.setId(999L);
+                originalItems.add(fee);
+                when(items.findById(999L)).thenReturn(java.util.Optional.of(fee));
+                return 999;
+            });
+    }
+
+    @AfterEach
+    void tearDown() {
+        paymentsMock.close();
+        propMock.close();
+        cloudMock.close();
+        originalSettings.forEach(Constants::setString);
+        Constants.setInstallName(originalInstallName);
+    }
+
+    /** Checkout refreshes prices, includes fees and saves amounts that can be rebuilt from existing fields. */
+    @Test
+    void savesCurrentPricesAndFees() {
+        config("currencyFormat", "0.0000");
+        product(100, "1.594", 23, 3);
+        product(200, "0.0001", 0, 10000);
+        delivery.setPrice(new BigDecimal("1.594"));
+        assertTrue(service.addDeliveryMethod(request, 1, prop));
+        verify(items, never()).save(any());
+        paymentNet = new BigDecimal("2.675");
+        request.setParameter("priceToPayVat", "0.01");
+        request.setParameter("currency", "usd");
+        List<BasketInvoiceItemEntity> stored = new ArrayList<>();
+        when(items.saveAll(any())).thenAnswer(call -> {
+            ((Iterable<BasketInvoiceItemEntity>) call.getArgument(0)).forEach(stored::add);
+            return stored;
+        });
+        when(invoices.save(any())).thenAnswer(call -> {
+            BasketInvoiceEntity invoice = call.getArgument(0);
+            invoice.setId(501L);
+            return invoice;
+        });
+        PlatformTransactionManager manager = transactionManager();
+        try (MockedStatic<Tools> tools = transactionTools(manager);
+             MockedStatic<Adminlog> audit = mockStatic(Adminlog.class);
+             MockedStatic<PageLng> language = mockStatic(PageLng.class)) {
+            BasketInvoiceEntity invoice = service.saveOrder(request);
+            assertNotNull(invoice);
+            assertEquals(new BigDecimal("11.15"), invoice.getTotalPriceVat());
+            assertEquals(new BigDecimal("10.05"), invoice.getTotalPrice());
+            assertEquals("eur", invoice.getCurrency());
+            assertEquals(4, stored.size());
+            assertTrue(stored.stream().allMatch(row -> row.getInvoiceId() == 501));
+            for (BasketInvoiceItemEntity row : stored) {
+                row.setItemPrice(BigDecimal.valueOf(row.getItemPrice().doubleValue()));
+                row.setRoundedUnitPriceVat(null);
+                row.setLineVatAmount(null);
+            }
+            BasketPricingService.allocateVat(stored);
+            assertEquals(new BigDecimal("11.15"), EshopService.getTotalLocalPriceVat(stored, request));
+            assertEquals(new BigDecimal("10.05"), EshopService.getTotalLocalPrice(stored, request));
+            verify(manager).commit(any());
+            assertNull(request.getSession().getAttribute("BasketDB.browserIdSession"));
+        }
+    }
+
+    /** Persistence and commit failures leave the customer's basket session intact. */
+    @org.junit.jupiter.params.ParameterizedTest
+    @org.junit.jupiter.params.provider.ValueSource(booleans = { false, true })
+    void retainsBasketOnFailedOrder(boolean commitFails) {
+        product(100, "1.594", 0, 3);
+        PlatformTransactionManager manager = transactionManager();
+        if (commitFails) {
+            when(invoices.save(any())).thenAnswer(call -> {
+                BasketInvoiceEntity invoice = call.getArgument(0);
+                invoice.setId(501L);
+                return invoice;
+            });
+            doThrow(new IllegalStateException("Commit failure")).when(manager).commit(any());
+        } else when(invoices.save(any())).thenThrow(new IllegalStateException("Save failure"));
+        try (MockedStatic<Tools> tools = transactionTools(manager);
+             MockedStatic<Adminlog> audit = mockStatic(Adminlog.class)) {
+            assertNull(service.saveOrder(request));
+            if (commitFails) verify(manager).commit(any());
+            else verify(manager).rollback(any());
+            assertEquals("100", request.getSession().getAttribute("BasketDB.browserIdSession"));
+        }
+    }
+
+    private BasketInvoiceItemEntity product(long id, String net, int vat, int quantity) {
+        DocDetails doc = mock(DocDetails.class);
+        when(doc.getPrice(request)).thenReturn(new BigDecimal(net));
+        when(doc.getVat()).thenReturn(BigDecimal.valueOf(vat));
+        when(doc.getCurrency()).thenReturn("eur");
+        when(doc.getTitle()).thenReturn("Product " + id);
+        BasketInvoiceItemEntity item = new BasketInvoiceItemEntity();
+        item.setId(id);
+        item.setBrowserId(100L);
+        item.setDomainId(1);
+        item.setItemId((int) id + 1000);
+        item.setItemPrice(new BigDecimal("99"));
+        item.setItemVat(vat);
+        item.setItemQty(quantity);
+        item.setDoc(doc);
+        originalItems.add(item);
+        return item;
+    }
+
+    private BasketInvoiceItemEntity fee() {
+        BasketInvoiceItemEntity item = new BasketInvoiceItemEntity();
+        item.setItemId(0);
+        item.setItemTitle("Payment");
+        item.setItemNote("Payment fee");
+        item.setItemPrice(paymentNet);
+        item.setItemVat(0);
+        item.setItemQty(1);
+        return item;
+    }
+
+    private PlatformTransactionManager transactionManager() {
+        PlatformTransactionManager manager = mock(PlatformTransactionManager.class);
+        when(manager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+        return manager;
+    }
+
+    private MockedStatic<Tools> transactionTools(PlatformTransactionManager manager) {
+        return mockStatic(Tools.class, call -> {
+            if ("getSpringBean".equals(call.getMethod().getName()) && "webjet2022TransactionManager".equals(call.getArgument(0))) return manager;
+            return call.callRealMethod();
+        });
+    }
+
+    private void config(String key, String value) {
+        originalSettings.putIfAbsent(key, Constants.getString(key));
+        Constants.setString(key, value);
+    }
+}

--- a/src/test/webapp/tests/apps/basket/rounding.js
+++ b/src/test/webapp/tests/apps/basket/rounding.js
@@ -1,0 +1,243 @@
+Feature('apps.basket.rounding');
+
+const SL = require('./SL');
+
+const configuration = {};
+const products = [];
+let marker;
+
+Before(({ I, login }) => {
+    login('admin');
+    if (marker == null) marker = 'rounding-autotest-' + I.getRandomText();
+});
+
+Scenario('Prepare isolated rounding products and preserve configuration', async ({ I, DT }) => {
+    I.amOnPage(SL.PRODUCTS_ADMIN);
+    DT.waitForLoader();
+    for (const name of ['basketRoundPrices', 'basketDisplayCurrency', 'basketProductCurrency', 'basketMaxQty', 'currencyTagRound', 'currencyFormat']) {
+        configuration[name] = await browserRequest(I, '/admin/rest/settings/configuration/autocomplete/detail?name=' + name);
+    }
+    await setConfig(I, 'basketRoundPrices', 'false');
+    await setConfig(I, 'basketDisplayCurrency', 'eur');
+    await setConfig(I, 'basketProductCurrency', 'eur');
+    await setConfig(I, 'currencyTagRound', 'false');
+    await setConfig(I, 'currencyFormat', '###,##0.00');
+
+    const source = await I.executeScript(() => {
+        const rows = productListDataTable.rows().data().toArray();
+        return rows.find(row => row.title === 'Ponožky') || rows[0];
+    });
+    I.assertTrue(source != null, 'The standard basket product directory must contain a source product');
+    const sourceDetail = await browserRequest(I, '/admin/rest/web-pages/' + (source.docId || source.id));
+    for (const fixture of [
+        { suffix: 'down', net: '1.594', vat: '0', display: '1,59', quantity: 3, total: '4,77' },
+        { suffix: 'tie', net: '1.595', vat: '0', display: '1,60', quantity: 2, total: '3,20' },
+        { suffix: 'vat', net: '1.30', vat: '23', display: '1,60', quantity: 3, total: '4,80' },
+        { suffix: 'micro', net: '0.0001', vat: '0' }
+    ]) {
+        const product = await browserRequest(I, '/admin/rest/web-pages/-1?groupId=' + sourceDetail.groupId);
+        Object.assign(product, {
+            id: -1, docId: -1, title: marker + '-' + fixture.suffix, navbar: marker + '-' + fixture.suffix,
+            groupId: sourceDetail.groupId, tempId: sourceDetail.tempId, available: true,
+            data: sourceDetail.data + '\n!INCLUDE(/components/basket/addbasket.jsp)!',
+            perex: sourceDetail.perex, perexImage: sourceDetail.perexImage,
+            fieldJ: 'eur', fieldK: fixture.net, fieldL: fixture.vat, fieldM: '0', virtualPath: ''
+        });
+        const result = await browserRequest(I, '/admin/rest/web-pages/editor', { action: 'create', data: { 0: product } });
+        I.assertTrue(result.data != null && result.data.length === 1, 'The rounding product must be created');
+        products.push({ ...fixture, ...result.data[0], docId: result.data[0].docId || result.data[0].id });
+    }
+    SL.clearBasket(I);
+});
+
+Scenario('Legacy mode retains basket rounding after multiplication', async ({ I }) => {
+    I.assertEqual(4, products.length, 'All rounding fixtures must exist');
+    const product = products[0];
+    await addProduct(I, product, 3);
+    I.waitForText('4,78', 10, '.basketSmallPrice');
+    I.amOnPage(SL.BASKET);
+    I.waitForText('4,78', 10, '.basketListTable');
+    SL.clearBasket(I);
+});
+
+Scenario('Round two-decimal gross units before quantity and ignore coarse currency rounding', async ({ I }) => {
+    I.amOnPage(SL.PRODUCTS_ADMIN);
+    await setConfig(I, 'basketRoundPrices', 'true');
+    await setConfig(I, 'currencyTagRound', 'true');
+    await setConfig(I, 'currencyFormat', '0.00');
+    SL.clearBasket(I);
+
+    for (const product of products.filter(product => product.suffix !== 'micro')) {
+        I.amOnPage(SL.PRODUCTS);
+        const card = locate('.thumbnail').withText(product.title);
+        I.waitForVisible(card, 10);
+        I.assertEqual(product.display + ' €', await sellingPrice(I, product),
+            'The product list must show exactly two decimal places');
+        await addProduct(I, product, product.quantity);
+    }
+
+    I.waitForText('12,77', 10, '.basketSmallPrice');
+    I.amOnPage(SL.BASKET);
+    for (const product of products.filter(product => product.suffix !== 'micro')) {
+        const row = locate('tr.itemTr').withText(product.title);
+        I.waitForVisible(row, 10);
+        I.assertEqual(product.display + ' €', normalizePrice(await I.grabTextFrom(row.find('td.basketPrice'))),
+            'The basket unit price must match the product list');
+        I.assertEqual(product.total + ' €', normalizePrice(await I.grabTextFrom(row.find('td').at(4))),
+            'The basket line must equal the displayed unit price multiplied by quantity');
+    }
+    I.assertEqual('12,77 €', normalizePrice(await I.grabTextFrom('.basketPriceText + .basketPrice')),
+        'The basket total must equal the sum of its displayed lines');
+
+    I.click(locate('tr.itemTr').withText(products[0].title).find('.addItem'));
+    I.waitForText('14,36', 10, '.basketPriceText + .basketPrice');
+    I.refreshPage();
+    I.waitForText('14,36', 10, '.basketPriceText + .basketPrice');
+
+    I.amOnPage('/showdoc.do?docid=' + products[0].docId);
+    I.waitForText('1,59', 10, '.priceSpan, .priceDiv, .price');
+    I.dontSee('1,5900', '.priceSpan, .priceDiv, .price');
+});
+
+Scenario('Four-decimal units preserve small prices and settle quantity totals to cents', async ({ I }) => {
+    I.amOnPage(SL.PRODUCTS_ADMIN);
+    await setConfig(I, 'currencyFormat', '0.0000');
+    await setConfig(I, 'basketMaxQty', '10000');
+    SL.clearBasket(I);
+    const product = products.find(product => product.suffix === 'down');
+    const micro = products.find(product => product.suffix === 'micro');
+    I.assertEqual('1,5940 €', await sellingPrice(I, product));
+    I.assertEqual('0,0001 €', await sellingPrice(I, micro));
+    await addProduct(I, product, 3);
+    await addProduct(I, micro, 1);
+
+    I.amOnPage(SL.BASKET);
+    const productRow = locate('tr.itemTr').withText(product.title);
+    const microRow = locate('tr.itemTr').withText(micro.title);
+    I.assertEqual('1,5940 €', normalizePrice(await I.grabTextFrom(productRow.find('td.basketPrice'))));
+    I.assertEqual('4,7800 €', normalizePrice(await I.grabTextFrom(productRow.find('td').at(4))));
+    for (const update of [{ quantity: '100', total: '4,7900' }, { quantity: '155', total: '4,8000' }]) {
+        I.refreshPage();
+        I.waitForVisible(microRow, 10);
+        // Replace the selected value without triggering the minimum clamp on an empty field.
+        I.click(microRow.find('input.basketQty'));
+        I.pressKey(['CommandOrControl', 'A']);
+        I.type(update.quantity);
+        I.assertEqual(update.quantity, await I.grabValueFrom(microRow.find('input.basketQty')),
+            'The exact requested quantity must be present before submitting the update');
+        I.pressKey('Tab');
+        I.waitForFunction(() => jQuery.active === 0, 10);
+        I.waitForText(update.total, 10, '.basketPriceText + .basketPrice');
+    }
+    I.assertEqual('0,0001 €', normalizePrice(await I.grabTextFrom(microRow.find('td.basketPrice'))));
+    I.assertEqual('0,0200 €', normalizePrice(await I.grabTextFrom(microRow.find('td').at(4))));
+    I.refreshPage();
+    I.waitForText('4,8000', 10, '.basketPriceText + .basketPrice');
+
+    I.amOnPage('/showdoc.do?docid=' + micro.docId);
+    I.waitForText('0,0001', 10, '.priceSpan');
+});
+
+Scenario('Low-precision unit policies still display at least two decimals everywhere', async ({ I }) => {
+    const product = products.find(product => product.suffix === 'down');
+    for (const example of [
+        { pattern: '0', scale: 0, unit: '2,00', total: '6,00' },
+        { pattern: '0.0', scale: 1, unit: '1,60', total: '4,80' }
+    ]) {
+        I.amOnPage(SL.PRODUCTS_ADMIN);
+        await setConfig(I, 'currencyFormat', example.pattern);
+        SL.clearBasket(I);
+        I.assertEqual(example.unit + ' €', await sellingPrice(I, product),
+            'Unit display must retain two decimals without changing the configured rounding precision');
+        await addProduct(I, product, 3);
+        I.waitForText(example.total, 10, '.basketSmallPrice');
+
+        I.amOnPage(SL.BASKET);
+        const row = locate('tr.itemTr').withText(product.title);
+        I.waitForVisible(row, 10);
+        I.assertEqual(example.unit + ' €', normalizePrice(await I.grabTextFrom(row.find('td.basketPrice'))));
+        I.assertEqual(example.total + ' €', normalizePrice(await I.grabTextFrom(row.find('td').at(4))));
+        I.amOnPage('/showdoc.do?docid=' + product.docId);
+        I.waitForText(example.unit, 10, '.priceSpan');
+    }
+});
+
+Scenario('Remove rounding products and clear the test basket', async ({ I }) => {
+    SL.clearBasket(I);
+    I.amOnPage(SL.PRODUCTS_ADMIN);
+    for (const product of products) {
+        I.assertTrue(product.title.startsWith(marker), 'Cleanup may only delete products created by this test');
+        const result = await browserRequest(I, '/admin/rest/web-pages/editor', {
+            action: 'remove', data: { [product.docId]: { id: product.docId, docId: product.docId } }
+        });
+        I.assertFalse(Boolean(result.error), 'The rounding product must be removed');
+    }
+});
+
+Scenario('Restore rounding configuration', async ({ I }) => {
+    I.amOnPage('/admin/v9/settings/configuration/');
+    for (const [name, original] of Object.entries(configuration)) {
+        if (original.databaseValuePresent) {
+            await setConfig(I, name, original.value);
+        } else {
+            const current = await browserRequest(I, '/admin/rest/settings/configuration/autocomplete/detail?name=' + name);
+            await browserRequest(I, '/admin/rest/settings/configuration/editor', {
+                action: 'remove', data: { [current.id]: current }
+            });
+        }
+        if (original.runtimeValueDifferent) {
+            await browserRequest(I, '/admin/rest/settings/configuration/editor', {
+                action: 'create', data: { 0: { name, value: original.displayValue, temporary: true } }
+            });
+        }
+    }
+});
+
+/** Adds a fixture through the existing product UI and waits for each quantity update. */
+async function addProduct(I, product, quantity) {
+    I.amOnPage(SL.PRODUCTS);
+    const button = locate('.thumbnail').withText(product.title).find('.addToBasket');
+    I.waitForVisible(button, 10);
+    for (let index = 0; index < quantity; index++) {
+        I.click(button);
+        I.waitForFunction(() => typeof jQuery === 'undefined' || jQuery.active === 0, 10);
+    }
+}
+
+/** Reads the current price without the crossed-out previous price in the same container. */
+async function sellingPrice(I, product) {
+    const value = await I.executeScript(title => {
+        const productCard = [...document.querySelectorAll('.thumbnail')].find(element => element.textContent.includes(title));
+        const price = productCard.querySelector('.price').cloneNode(true);
+        price.querySelectorAll('.cenaOld').forEach(element => element.remove());
+        return price.textContent;
+    }, product.title);
+    return normalizePrice(value);
+}
+
+/** Sends requests with the same session and CSRF token as the browser. */
+async function browserRequest(I, url, body) {
+    return I.executeScript(async ({ url, body }) => {
+        const response = await fetch(url, {
+            method: body == null ? 'GET' : 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window.csrfToken },
+            body: body == null ? undefined : JSON.stringify(body)
+        });
+        if (!response.ok) throw new Error('The rounding fixture request failed: ' + response.status + ' ' + url);
+        const result = await response.json();
+        if (result.error || (result.fieldErrors != null && result.fieldErrors.length > 0)) {
+            throw new Error('The rounding fixture request was rejected: ' + JSON.stringify(result));
+        }
+        return result;
+    }, { url, body });
+}
+
+async function setConfig(I, name, value) {
+    await browserRequest(I, '/admin/rest/settings/configuration/editor', {
+        action: 'create', data: { 0: { name, value } }
+    });
+}
+
+function normalizePrice(value) {
+    return value.replace(/\u00a0/g, ' ').replace(/\s+/g, ' ').trim();
+}


### PR DESCRIPTION
Je potrebné pridať možnosť povoliť zaokrúhľovanie ceny tak, aby sa výsledná cena celého nákupu v košíku e-shopu nelíšila o centy od zobrazenej ceny jednotlivých položiek.